### PR TITLE
2077 feat create space for more bytecode encodings

### DIFF
--- a/pkg/zkc/vm/debug.go
+++ b/pkg/zkc/vm/debug.go
@@ -37,7 +37,9 @@ func BootAndDebug[W Word[W]](program Program[W], in map[string][]byte, observer 
 		fid, pc, frame := interpreter.ExtractExecutingState(bci)
 		// Clone the frame so the observer sees a stable snapshot which cannot be
 		// mutated by subsequent execution.
-		observer(State[W]{fid, pc, opcode == encoding.RET, slices.Clone(frame)})
+		returning := opcode == encoding.RET || opcode == encoding.WIDE|encoding.WIDE_RET<<8
+		//
+		observer(State[W]{fid, pc, returning, slices.Clone(frame)})
 	})
 	// Boot and execute to completion.
 	_, _, errs := BootAndExecute(bci, in, math.MaxUint)

--- a/pkg/zkc/vm/internal/interpreter/encoding/arith.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/arith.go
@@ -66,7 +66,7 @@ func Arith[W word.Word[W]](p bytecode.Arith[W], env Environment[W]) []uint32 {
 // first word, with both source registers in a second:
 //
 // +--------+--------+--------+--------+
-// |        rd       |  n/a   | opcode |
+// |        rd       |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       rs0       |       rs1       |
 // +-----------------+-----------------+
@@ -79,7 +79,7 @@ func encodeArith_2n1(aop bytecode.Operation, rs0, rs1, rd uint16) []uint32 {
 	//
 	if IsWideRegisters(rs0, rs1, rd) {
 		return []uint32{
-			uint32(rd)<<16 | opcode | WIDE,
+			uint32(rd)<<16 | (WIDE_ADD_2n1+uint32(aop-bytecode.OP_ADD))<<8 | WIDE,
 			uint32(rs1) | uint32(rs0)<<16,
 		}
 	}
@@ -122,7 +122,7 @@ func DecodeArith_2n1(pc uint32, codes []uint32) (rs0, rs1, rd uint16, n uint32) 
 // the (now u16) registers into a subsequent word:
 //
 // +--------+--------+--------+--------+
-// |       cid       |  n/a   | opcode |
+// |       cid       |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       rs        |        rd       |
 // +-----------------+-----------------+
@@ -160,7 +160,7 @@ func encodeArith_1n1c[W word.Word[W]](aop bytecode.Operation, rs, rd uint16, con
 	// form only a u8 immediate.
 	if IsWideRegisters(rs, rd) || constant.Cmp64(0xff) > 0 {
 		return []uint32{
-			uint32(env.ConstantIndex(constant))<<16 | opcode | WIDE,
+			uint32(env.ConstantIndex(constant))<<16 | (WIDE_ADDC+uint32(aop-bytecode.OP_ADD))<<8 | WIDE,
 			uint32(rd) | uint32(rs)<<16,
 		}
 	}
@@ -245,7 +245,7 @@ func DecodeLdc_1[W word.Word[W]](pc uint32, codes []uint32) (constant W, rd uint
 // register into a subsequent word:
 //
 // +--------+--------+--------+--------+
-// |       cid       |  n/a   | opcode |
+// |       cid       |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       n/a       |        rd       |
 // +-----------------+-----------------+
@@ -258,7 +258,7 @@ func encodeLdc_w[W word.Word[W]](constant W, rd uint16, env Environment[W]) []ui
 	//
 	if IsWideRegisters(rd) {
 		return []uint32{
-			cid<<16 | LDC_w | WIDE,
+			cid<<16 | WIDE_LDC_w<<8 | WIDE,
 			uint32(rd),
 		}
 	}
@@ -293,7 +293,7 @@ func DecodeLdc_w[W word.Word[W]](pc uint32, codes []uint32, pool []W) (constant 
 // The wide form moves the (now u16) registers into a subsequent word:
 //
 // +--------+--------+--------+--------+
-// |           n/a            | opcode |
+// |       n/a       |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       rs        |        rd       |
 // +-----------------+-----------------+
@@ -303,7 +303,7 @@ func DecodeLdc_w[W word.Word[W]](pc uint32, codes []uint32, pool []W) (constant 
 func encodeMove_1s1(rs, rd uint16) []uint32 {
 	if IsWideRegisters(rs, rd) {
 		return []uint32{
-			MOVE | WIDE,
+			WIDE_MOVE<<8 | WIDE,
 			uint32(rd) | uint32(rs)<<16,
 		}
 	}
@@ -353,7 +353,7 @@ func DecodeMove_1s1(pc uint32, codes []uint32) (rs, rd uint16, n uint32) {
 // u16) target and source registers two per word:
 //
 // +--------+--------+--------+--------+
-// |   bw   |  nsrc  |  n/a   | opcode |
+// |   bw   |  nsrc  |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |      ntgt       |       cid       |
 // +-----------------+-----------------+
@@ -394,7 +394,10 @@ func encodeArith_vec[W word.Word[W]](aop bytecode.Operation, targets []RegisterI
 	)
 	//
 	if IsWideRegisters(regs...) {
-		codes := []uint32{bw | nsrc | opcode | WIDE, uint32(len(targets))<<16 | cid}
+		codes := []uint32{
+			bw | nsrc | (WIDE_ADD_nm+uint32(aop-bytecode.OP_ADD))<<8 | WIDE,
+			uint32(len(targets))<<16 | cid,
+		}
 		//
 		return append(codes, PackShortsIntoCodes(regs)...)
 	}

--- a/pkg/zkc/vm/internal/interpreter/encoding/arith.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/arith.go
@@ -13,8 +13,6 @@
 package encoding
 
 import (
-	"math/big"
-
 	"github.com/LFDT-Lineth/zkc/pkg/util"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/bytecode"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/descriptor"
@@ -29,26 +27,26 @@ func Arith[W word.Word[W]](p bytecode.Arith[W], env Environment[W]) []uint32 {
 		n             = len(p.Source)
 		m             = len(p.Target)
 		cz            = bytecode.IsUnusedConstant(p.Op, p.Constant)
-		constIsUint24 = p.Constant.Cmp64(0x100_0000) < 0
+		constIsUint16 = p.Constant.Cmp64(0x1_0000) < 0
 	)
 	//
 	switch {
-	case n == 0 && m == 1 && constIsUint24:
+	case n == 0 && m == 1 && constIsUint16 && !IsWideRegisters(p.Target[0]):
 		return encodeLdc_1(p.Constant, p.Target[0])
 	case n == 0 && m == 1:
-		return encodeLdc_w(p.Constant, p.Target[0])
+		return encodeLdc_w(p.Constant, p.Target[0], env)
 	case n == 1 && m == 1 && cz:
 		return encodeMove_1s1(p.Source[0], p.Target[0])
-	case n == 1 && m == 1 && constIsUint24:
-		return encodeArith_1n1c(p.Op, p.Source[0], p.Target[0], p.Constant)
+	case n == 1 && m == 1:
+		return encodeArith_1n1c(p.Op, p.Source[0], p.Target[0], p.Constant, env)
 	case n == 2 && m == 1 && cz:
 		return encodeArith_2n1(p.Op, p.Source[0], p.Source[1], p.Target[0])
-	case n == 2 && m == 1 && constIsUint24 && p.Op != bytecode.OP_SUB:
+	case n == 2 && m == 1 && p.Op != bytecode.OP_SUB:
 		// SUB is excluded: the two-step pairing wraps each step separately,
 		// which is not equivalent to the single wrap (at CalculateSubBitwidth
 		// width) that the vectored form performs when the first step
 		// underflows.  See encodeArith_2n1c.
-		return encodeArith_2n1c(p.Op, p.Source[0], p.Source[1], p.Target[0], p.Constant)
+		return encodeArith_2n1c(p.Op, p.Source[0], p.Source[1], p.Target[0], p.Constant, env)
 	default:
 		return encodeArith_vec(p.Op, p.Target, p.Source, p.Constant, env)
 	}
@@ -120,11 +118,11 @@ func DecodeArith_2n1(pc uint32, codes []uint32) (rs0, rs1, rd uint16, n uint32) 
 //
 // Here, rs is a u8 source register, rd is a u8 destination register, imm8 is
 // the small constant operand and opcode is ADDC, SUBC or MULC.  The wide form
-// extends the constant operand to imm24, moving the (now u16) registers into a
-// subsequent word:
+// replaces the constant operand with a u16 constant pool identifier, moving
+// the (now u16) registers into a subsequent word:
 //
 // +--------+--------+--------+--------+
-// |           imm24          | opcode |
+// |       cid       |  n/a   | opcode |
 // +--------+--------+--------+--------+
 // |       rs        |        rd       |
 // +-----------------+-----------------+
@@ -138,7 +136,8 @@ func DecodeArith_2n1(pc uint32, codes []uint32) (rs0, rs1, rd uint16, n uint32) 
 // (a fold in two steps computes the same value as one), whereas a subtraction
 // wraps per-instruction on underflow, so splitting it would wrap at the wrong
 // width — SUB must use the vectored form instead (see Arith).
-func encodeArith_2n1c[W word.Word[W]](aop bytecode.Operation, rs0, rs1, rd uint16, constant W) []uint32 {
+func encodeArith_2n1c[W word.Word[W]](aop bytecode.Operation, rs0, rs1, rd uint16, constant W,
+	env Environment[W]) []uint32 {
 	// Sanity check
 	if aop == bytecode.OP_SUB {
 		panic("two-step encoding unsound for subtraction")
@@ -148,38 +147,34 @@ func encodeArith_2n1c[W word.Word[W]](aop bytecode.Operation, rs0, rs1, rd uint1
 	// one-source instruction operating in place on the target.
 	codes := encodeArith_2n1(aop, rs0, rs1, rd)
 	//
-	return append(codes, encodeArith_1n1c(aop, rd, rd, constant)...)
+	return append(codes, encodeArith_1n1c(aop, rd, rd, constant, env)...)
 }
 
 // encodeArith_1n1c encodes a one-source, one-target arithmetic-with-constant
 // instruction (ADDC/SUBC/MULC).
-func encodeArith_1n1c[W word.Word[W]](aop bytecode.Operation, rs, rd uint16, constant W) []uint32 {
-	if constant.Cmp64(0x100_0000) >= 0 {
-		panic("constant exceeds arithmetic-with-constant form")
-	}
+func encodeArith_1n1c[W word.Word[W]](aop bytecode.Operation, rs, rd uint16, constant W,
+	env Environment[W]) []uint32 {
 	//
-	var (
-		imm    = uint32(constant.Uint64())
-		opcode = ADDC + uint32(aop-bytecode.OP_ADD)
-	)
-	//
-	if IsWideRegisters(rs, rd) || imm > 0xff {
+	var opcode = ADDC + uint32(aop-bytecode.OP_ADD)
+	// The wide (pooled) form carries a constant of arbitrary width; the narrow
+	// form only a u8 immediate.
+	if IsWideRegisters(rs, rd) || constant.Cmp64(0xff) > 0 {
 		return []uint32{
-			imm<<8 | opcode | WIDE,
+			uint32(env.ConstantIndex(constant))<<16 | opcode | WIDE,
 			uint32(rd) | uint32(rs)<<16,
 		}
 	}
 	//
 	return []uint32{
-		imm<<24 | uint32(rs)<<16 | uint32(rd)<<8 | opcode,
+		uint32(constant.Uint64())<<24 | uint32(rs)<<16 | uint32(rd)<<8 | opcode,
 	}
 }
 
 // DecodeArith_1n1c decodes a one-source-plus-constant arithmetic instruction,
 // returning the source and destination registers, constant and instruction width.
-func DecodeArith_1n1c[W word.Word[W]](pc uint32, codes []uint32) (rs, rd uint16, constant W, n uint32) {
+func DecodeArith_1n1c[W word.Word[W]](pc uint32, codes []uint32, pool []W) (rs, rd uint16, constant W, n uint32) {
 	if IsWideForm(pc, codes) {
-		constant = constant.SetUint64(uint64(codes[pc] >> 8))
+		constant = pool[codes[pc]>>16]
 		rd = RegisterId(codes[pc+1] & 0xffff)
 		rs = RegisterId(codes[pc+1] >> 16)
 		//
@@ -203,54 +198,29 @@ func DecodeArith_1n1c[W word.Word[W]](pc uint32, codes []uint32) (rs, rd uint16,
 // +--------+--------+--------+--------+
 //
 // Here, rd is a u8 destination register and imm16 is the constant operand.
-// The wide form extends the constant operand to imm24, moving the (now u16)
-// destination register into a subsequent word:
-//
-// +--------+--------+--------+--------+
-// |           imm24          | opcode |
-// +--------+--------+--------+--------+
-// |       n/a       |        rd       |
-// +-----------------+-----------------+
-//
-// The wide form is also selected when the register is small but the constant
-// exceeds 16 bits, being no larger than the general Ldc_w form.
+// There is no wide form: a wide (u16) register, or a constant exceeding 16
+// bits, uses the pooled Ldc_w form instead (which is no larger).
 // ============================================================================
 
-// encodeLdc_1 encodes a load-constant instruction carrying a small (u16 or,
-// in the wide form, u24) constant into the target register.
+// encodeLdc_1 encodes a load-constant instruction carrying a small (u16)
+// constant into the target register.
 func encodeLdc_1[W word.Word[W]](constant W, rd uint16) []uint32 {
-	// Sanity checks.  Constants which do not fit within 24 bits must use the
-	// general form (see encodeLdc_w).
-	if constant.Cmp64(0x100_0000) >= 0 {
+	// Sanity checks.  Constants which do not fit within 16 bits, or wide
+	// registers, must use the pooled form (see encodeLdc_w).
+	if constant.Cmp64(0x1_0000) >= 0 || IsWideRegisters(rd) {
 		panic("constant exceeds short load form")
-	}
-	// Encoding
-	c := uint32(constant.Uint64())
-	//
-	if IsWideRegisters(rd) || c > 0xffff {
-		return []uint32{
-			c<<8 | LDC | WIDE,
-			uint32(rd),
-		}
 	}
 	//
 	return []uint32{
-		c<<16 | uint32(rd)<<8 | LDC,
+		uint32(constant.Uint64())<<16 | uint32(rd)<<8 | LDC,
 	}
 }
 
-// DecodeLdc_1 decodes a load-constant instruction carrying a small (u16 or,
-// in the wide form, u24) constant, returning the constant, destination
-// register and instruction width.
+// DecodeLdc_1 decodes a load-constant instruction carrying a small (u16)
+// constant, returning the constant, destination register and instruction
+// width.
 func DecodeLdc_1[W word.Word[W]](pc uint32, codes []uint32) (constant W, rd uint16, n uint32) {
 	var c W
-	//
-	if IsWideForm(pc, codes) {
-		c = c.SetUint64(uint64(codes[pc] >> 8))
-		rd = RegisterId(codes[pc+1] & 0xffff)
-		//
-		return c, rd, 2
-	}
 	//
 	c = c.SetUint64(uint64(codes[pc] >> 16))
 	rd = RegisterId((codes[pc] >> 8) & 0xff)
@@ -259,93 +229,55 @@ func DecodeLdc_1[W word.Word[W]](pc uint32, codes []uint32) (constant W, rd uint
 }
 
 // ============================================================================
-// Ldc_w (wide load constant) instruction.  Format of this instruction is:
+// Ldc_w (pooled load constant) instruction.  Format of this instruction is:
 //
 //	31                                0
 //
 // +--------+--------+--------+--------+
-// |      n          |   rd   | opcode |
+// |       cid       |   rd   | opcode |
 // +--------+--------+--------+--------+
-// |     limb 0 (least significant)    |
-// +-----------------------------------+
-// |                ...                |
-// +-----------------------------------+
-// |     limb n-1 (most significant)   |
-// +-----------------------------------+
 //
-// Here, rd is a u8 destination register and the constant is carried inline as
-// n 32-bit limbs (least significant first).  This form supports constants of
+// Here, rd is a u8 destination register and cid is a u16 constant pool
+// identifier for the constant operand.  This form supports constants of
 // arbitrary width (e.g. field-sized constants on a Uint machine), in contrast
 // to the short LDC form which carries a single 16-bit immediate.  The wide
-// form carries the (now u16) destination register in the first word, shrinking
-// the limb count to a u8 (i.e. wide-form constants are capped at 255 limbs, or
-// 8160 bits — far beyond anything computable, since vectored arithmetic is
-// itself capped at 255 bits):
+// form keeps the pool identifier in place, moving the (now u16) destination
+// register into a subsequent word:
 //
 // +--------+--------+--------+--------+
-// |        rd       | n (u8) | opcode |
+// |       cid       |  n/a   | opcode |
 // +--------+--------+--------+--------+
-// |     limb 0 (least significant)    |
-// +-----------------------------------+
-// |                ...                |
-// +-----------------------------------+
+// |       n/a       |        rd       |
+// +-----------------+-----------------+
 // ============================================================================
 
-// encodeLdc_w encodes a wide load-constant instruction, carrying the constant
-// inline as a sequence of 32-bit limbs (least significant first).
-func encodeLdc_w[W word.Word[W]](constant W, rd uint16) []uint32 {
-	var (
-		// NOTE: big-endian byte ordering
-		bytes  = constant.BigInt().Bytes()
-		nlimbs = max(1, (len(bytes)+3)/4)
-		wide   = IsWideRegisters(rd)
-		codes  = make([]uint32, nlimbs+1)
-	)
+// encodeLdc_w encodes a pooled load-constant instruction, carrying its
+// constant operand as a u16 constant pool identifier.
+func encodeLdc_w[W word.Word[W]](constant W, rd uint16, env Environment[W]) []uint32 {
+	var cid = uint32(env.ConstantIndex(constant))
 	//
-	if wide {
-		// The wide form carries only a u8 limb count.
-		if nlimbs > 0xff {
-			panic("constant exceeds wide load form")
+	if IsWideRegisters(rd) {
+		return []uint32{
+			cid<<16 | LDC_w | WIDE,
+			uint32(rd),
 		}
-		//
-		codes[0] = uint32(rd)<<16 | uint32(nlimbs)<<8 | LDC_w | WIDE
-	} else {
-		codes[0] = uint32(nlimbs)<<16 | uint32(rd)<<8 | LDC_w
-	}
-	// Pack bytes into limbs, least significant limb first.
-	for i, b := range bytes {
-		var k = uint(len(bytes) - 1 - i)
-		//
-		codes[1+(k/4)] |= uint32(b) << (8 * (k % 4))
 	}
 	//
-	return codes
+	return []uint32{
+		cid<<16 | uint32(rd)<<8 | LDC_w,
+	}
 }
 
-// DecodeLdc_w decodes a load-constant instruction carrying a wide constant,
-// returning the constant, destination register and instruction width.
-func DecodeLdc_w[W word.Word[W]](pc uint32, codes []uint32) (constant W, rd uint16, n uint32) {
-	var (
-		c      big.Int
-		limb   big.Int
-		nlimbs uint32
-	)
+// DecodeLdc_w decodes a pooled load-constant instruction, returning the
+// constant, destination register and instruction width.
+func DecodeLdc_w[W word.Word[W]](pc uint32, codes []uint32, pool []W) (constant W, rd uint16, n uint32) {
+	var cid = codes[pc] >> 16
 	//
 	if IsWideForm(pc, codes) {
-		nlimbs = (codes[pc] >> 8) & 0xff
-		rd = RegisterId(codes[pc] >> 16)
-	} else {
-		nlimbs = (codes[pc] >> 16) & 0xffff
-		rd = RegisterId((codes[pc] >> 8) & 0xff)
-	}
-	// Unpack limbs, most significant limb first.
-	for i := nlimbs; i > 0; i-- {
-		limb.SetUint64(uint64(codes[pc+i]))
-		c.Lsh(&c, 32)
-		c.Or(&c, &limb)
+		return pool[cid], RegisterId(codes[pc+1] & 0xffff), 2
 	}
 	//
-	return constant.SetBigInt(&c), rd, nlimbs + 1
+	return pool[cid], RegisterId((codes[pc] >> 8) & 0xff), 1
 }
 
 // ============================================================================
@@ -405,9 +337,7 @@ func DecodeMove_1s1(pc uint32, codes []uint32) (rs, rd uint16, n uint32) {
 // +--------+--------+--------+--------+
 // |   bw   |  nsrc  | ntgt   | opcode |
 // +--------+--------+--------+--------+
-// |        constant low 32 bits        |
-// +------------------------------------+
-// |        constant high 32 bits       |
+// |       cid (constant pool id)       |
 // +------------------------------------+
 // | tgt3   | tgt2   | tgt1   | tgt0   |
 // +--------+--------+--------+--------+
@@ -415,10 +345,22 @@ func DecodeMove_1s1(pc uint32, codes []uint32) (rs, rd uint16, n uint32) {
 // +------------------------------------+
 //
 // The arithmetic operation (add, subtract or multiply) is identified by the
-// opcode itself (ADD_nm, SUB_nm or MUL_nm).  Targets are packed first because
-// StoreAcross writes the low limbs first.  The wide form retains the header
-// and constant words but packs the (now u16) target and source registers two
-// per word.
+// opcode itself (ADD_nm, SUB_nm or MUL_nm), whilst the constant operand is
+// carried as a (u16) constant pool identifier.  Targets are packed first
+// because StoreAcross writes the low limbs first.  The wide form moves the
+// target count into the upper half of the constant pool word (leaving bits
+// 8-15 of the first word clear, as for all wide forms) and packs the (now
+// u16) target and source registers two per word:
+//
+// +--------+--------+--------+--------+
+// |   bw   |  nsrc  |  n/a   | opcode |
+// +--------+--------+--------+--------+
+// |      ntgt       |       cid       |
+// +-----------------+-----------------+
+// |       tgt1      |       tgt0      |
+// +-----------------+-----------------+
+// | ... packed source registers ...    |
+// +------------------------------------+
 // ============================================================================
 
 // encodeArith_vec encodes the general (multi-target, multi-source) vectored form
@@ -438,8 +380,6 @@ func encodeArith_vec[W word.Word[W]](aop bytecode.Operation, targets []RegisterI
 		panic("targetless arithmetic instructions not supported")
 	} else if len(targets) >= 256 || len(sources) >= 256 {
 		panic("vector arithmetic operand counts not supported")
-	} else if constant.Cmp64(^uint64(0)) > 0 {
-		panic("wide vector arithmetic constants not supported")
 	} else if bitwidth > 255 {
 		panic("wide vector arithmetic not supported")
 	}
@@ -449,18 +389,18 @@ func encodeArith_vec[W word.Word[W]](aop bytecode.Operation, targets []RegisterI
 		bw     = uint32(bitwidth) << 24
 		nsrc   = uint32(len(sources)) << 16
 		ntgt   = uint32(len(targets)) << 8
-		c      = constant.Uint64()
+		cid    = uint32(env.ConstantIndex(constant))
 		regs   = append(RegsAsShorts(targets), RegsAsShorts(sources)...)
 	)
 	//
 	if IsWideRegisters(regs...) {
-		codes := []uint32{bw | nsrc | ntgt | opcode | WIDE, uint32(c), uint32(c >> 32)}
+		codes := []uint32{bw | nsrc | opcode | WIDE, uint32(len(targets))<<16 | cid}
 		//
 		return append(codes, PackShortsIntoCodes(regs)...)
 	}
 	//
 	var (
-		codes    = []uint32{bw | nsrc | ntgt | opcode, uint32(c), uint32(c >> 32)}
+		codes    = []uint32{bw | nsrc | ntgt | opcode, cid}
 		regBytes = append(RegsAsBytes(targets), RegsAsBytes(sources)...)
 	)
 	//
@@ -470,27 +410,29 @@ func encodeArith_vec[W word.Word[W]](aop bytecode.Operation, targets []RegisterI
 // DecodeArith_nm decodes a vectored (multi-target, multi-source) arithmetic
 // instruction, returning iterators over its target and source registers, the
 // constant operand and the instruction width.
-func DecodeArith_nm[W word.Word[W]](pc uint32, codes []uint32) (
+func DecodeArith_nm[W word.Word[W]](pc uint32, codes []uint32, pool []W) (
 	targets, sources Operands, constant W, bitwidth uint, n uint32) {
 	//
 	var (
-		ntargets = uint((codes[pc] >> 8) & 0xff)
 		nsources = uint((codes[pc] >> 16) & 0xff)
 		bw       = uint((codes[pc] >> 24) & 0xff)
-		c        = uint64(codes[pc+1]) | (uint64(codes[pc+2]) << 32)
 	)
 	//
 	if IsWideForm(pc, codes) {
-		targets = NewWideOperands(0, ntargets, codes[pc+3:])
-		sources = NewWideOperands(ntargets, nsources, codes[pc+3:])
-		n = 3 + NumCodesPackedWide(ntargets+nsources)
+		var ntargets = uint(codes[pc+1] >> 16)
+		//
+		constant = pool[codes[pc+1]&0xffff]
+		targets = NewWideOperands(0, ntargets, codes[pc+2:])
+		sources = NewWideOperands(ntargets, nsources, codes[pc+2:])
+		n = 2 + NumCodesPackedWide(ntargets+nsources)
 	} else {
-		targets = NewOperands(0, ntargets, codes[pc+3:])
-		sources = NewOperands(ntargets, nsources, codes[pc+3:])
-		n = 3 + NumCodesPackedSmall(ntargets+nsources)
+		var ntargets = uint((codes[pc] >> 8) & 0xff)
+		//
+		constant = pool[codes[pc+1]]
+		targets = NewOperands(0, ntargets, codes[pc+2:])
+		sources = NewOperands(ntargets, nsources, codes[pc+2:])
+		n = 2 + NumCodesPackedSmall(ntargets+nsources)
 	}
-	//
-	constant = constant.SetUint64(c)
 	//
 	return targets, sources, constant, bw, n
 }

--- a/pkg/zkc/vm/internal/interpreter/encoding/binary.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/binary.go
@@ -28,6 +28,9 @@ type Binary[W word.Word[W]] struct {
 	env SymbolTable[W]
 	// Compiled program being executed
 	bytecodes []uint32
+	// Constant pool referenced (by index) from instructions whose constant
+	// operand is not carried inline.
+	constants []W
 	// Mapping from addresses in the encoded binary program back to their
 	// relevant labels.  This can be used to determine the function at a given
 	// address and/or the appropriate PC value.
@@ -44,12 +47,17 @@ func NewBinary[W word.Word[W]](env SymbolTable[W], bytecodes []uint32) Binary[W]
 		}
 	}
 	//
-	return Binary[W]{env, bytecodes, rmap}
+	return Binary[W]{env, bytecodes, env.Constants(), rmap}
 }
 
 // Bytecodes returns the raw bytecode sequence
 func (p Binary[W]) Bytecodes() []uint32 {
 	return p.bytecodes
+}
+
+// Constants returns the constant pool.
+func (p Binary[W]) Constants() []W {
+	return p.constants
 }
 
 // Chunks returns formatted chunks needed for I/O instructions.

--- a/pkg/zkc/vm/internal/interpreter/encoding/bitwise.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/bitwise.go
@@ -37,7 +37,7 @@ func Bitwise[W word.Word[W]](p *bytecode.Bitwise[W]) []uint32 {
 // both source registers in a third:
 //
 // +--------+--------+--------+--------+
-// |        rd       |  n/a   | opcode |
+// |        rd       |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       n/a       |     bitwidth    |
 // +-----------------+-----------------+
@@ -52,7 +52,7 @@ func encodeBitwise(op bytecode.Operation, rd, lhs, rhs RegisterId, bitwidth uint
 	//
 	if IsWideRegisters(rd, lhs, rhs) {
 		return []uint32{
-			uint32(rd)<<16 | opcode | WIDE,
+			uint32(rd)<<16 | (WIDE_AND+uint32(op-bytecode.OP_AND))<<8 | WIDE,
 			uint32(bitwidth),
 			uint32(lhs) | uint32(rhs)<<16,
 		}

--- a/pkg/zkc/vm/internal/interpreter/encoding/bitwise.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/bitwise.go
@@ -29,8 +29,8 @@ func Bitwise[W word.Word[W]](p *bytecode.Bitwise[W]) []uint32 {
 // +--------+--------+--------+--------+
 // | amount | source |   rd   | opcode |
 // +--------+--------+--------+--------+
-// |                 |     bitwidth    |
-// +--------+--------+--------+--------+
+// |       n/a       |     bitwidth    |
+// +-----------------+-----------------+
 //
 // The opcode itself distinguishes the operations, so no width is needed.  The
 // wide form carries the (now u16) destination register in the first word, with
@@ -39,8 +39,8 @@ func Bitwise[W word.Word[W]](p *bytecode.Bitwise[W]) []uint32 {
 // +--------+--------+--------+--------+
 // |        rd       |  n/a   | opcode |
 // +--------+--------+--------+--------+
-// |                 |     bitwidth    |
-// +--------+--------+--------+--------+
+// |       n/a       |     bitwidth    |
+// +-----------------+-----------------+
 // |     amount      |      source     |
 // +-----------------+-----------------+
 // ============================================================================

--- a/pkg/zkc/vm/internal/interpreter/encoding/call.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/call.go
@@ -74,7 +74,7 @@ func MaxCallEncodedLength[W word.Word[W]](p *bytecode.Call[W]) uint {
 // packed slot:
 //
 // +--------+--------+--------+--------+
-// |      width      |  n/a   | opcode |
+// |      width      |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // | ............ target ............. |
 // +--------+--------+--------+--------+
@@ -101,7 +101,7 @@ func encodeEnter_n(pc, target uint32, width uint16, args []RegisterId) []uint32 
 	// absolute).
 	if width > math.MaxUint8 || !ok || IsWideRegisters(args...) {
 		codes := []uint32{
-			uint32(width)<<16 | opcode | WIDE,
+			uint32(width)<<16 | WIDE_ENTER_n<<8 | WIDE,
 			target,
 		}
 		// nargs occupies the first packed slot, followed by the arguments.
@@ -159,7 +159,7 @@ func DecodeEnter_n(pc uint32, codes []uint32) (width uint16, target uint32, args
 // packs the (now u16) return registers two per word:
 //
 // +-----------------+--------+--------+
-// |      nrets      |  n/a   | opcode |
+// |      nrets      |  wop   |  WIDE  |
 // +-----------------+--------+--------+
 // |       ret1      |       ret0      |
 // +-----------------+-----------------+
@@ -175,7 +175,7 @@ func encodeLeave_n(rets []RegisterId) []uint32 {
 	var nrets = uint32(len(rets))
 	//
 	if IsWideRegisters(rets...) {
-		var codes = []uint32{nrets<<16 | LEAVE_n | WIDE}
+		var codes = []uint32{nrets<<16 | WIDE_LEAVE_n<<8 | WIDE}
 		//
 		return append(codes, PackShortsIntoCodes(RegsAsShorts(rets))...)
 	}

--- a/pkg/zkc/vm/internal/interpreter/encoding/call.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/call.go
@@ -40,7 +40,7 @@ func Call[W word.Word[W]](pc uint32, p *bytecode.Call[W], env Environment[W]) (c
 // ENTER/LEAVE pair (the wide form is never smaller than the narrow form).
 func MaxCallEncodedLength[W word.Word[W]](p *bytecode.Call[W]) uint {
 	var (
-		enter = 2 + NumCodesPackedWide(uint(len(p.Arguments)))
+		enter = 2 + NumCodesPackedWide(uint(len(p.Arguments))+1)
 		leave = 1 + NumCodesPackedWide(uint(len(p.Returns)))
 	)
 	//
@@ -67,15 +67,20 @@ func MaxCallEncodedLength[W word.Word[W]](p *bytecode.Call[W]) uint {
 //
 // Here, nargs determines the number of packed argument registers, whilst width
 // determines the frame width to allocate and offset determines (relative)
-// offset to the target.  The wide form carries a u16 frame width, an absolute
-// u32 target address and (now u16) argument registers packed two per word:
+// offset to the target.  The wide form carries a u16 frame width (leaving
+// bits 8-15 clear, as for all wide forms) and an absolute u32 target address,
+// with the argument count and the (now u16) argument registers packed two per
+// word — mirroring the narrow form, where nargs likewise occupies the first
+// packed slot:
 //
 // +--------+--------+--------+--------+
-// |      width      | nargs  | opcode |
+// |      width      |  n/a   | opcode |
 // +--------+--------+--------+--------+
 // | ............ target ............. |
 // +--------+--------+--------+--------+
-// |  arg1  |  arg0   (u16 pairs) ...  |
+// |       arg0      |      nargs      |
+// +-----------------+-----------------+
+// |       arg2      |       arg1      |
 // +-----------------+-----------------+
 // ============================================================================
 
@@ -96,11 +101,13 @@ func encodeEnter_n(pc, target uint32, width uint16, args []RegisterId) []uint32 
 	// absolute).
 	if width > math.MaxUint8 || !ok || IsWideRegisters(args...) {
 		codes := []uint32{
-			uint32(width)<<16 | uint32(len(args))<<8 | opcode | WIDE,
+			uint32(width)<<16 | opcode | WIDE,
 			target,
 		}
+		// nargs occupies the first packed slot, followed by the arguments.
+		shorts := append([]uint16{uint16(len(args))}, RegsAsShorts(args)...)
 		//
-		return append(codes, PackShortsIntoCodes(RegsAsShorts(args))...)
+		return append(codes, PackShortsIntoCodes(shorts)...)
 	}
 	//
 	var (
@@ -116,12 +123,12 @@ func encodeEnter_n(pc, target uint32, width uint16, args []RegisterId) []uint32 
 // DecodeEnter_n decodes the operands of an enter (function entry) instruction.
 func DecodeEnter_n(pc uint32, codes []uint32) (width uint16, target uint32, args Operands, n uint32) {
 	if IsWideForm(pc, codes) {
-		var nargs = uint((codes[pc] >> 8) & 0xff)
+		var nargs = uint(codes[pc+2] & 0xffff)
 		//
 		width = uint16(codes[pc] >> 16)
 		target = codes[pc+1]
-		args = NewWideOperands(0, nargs, codes[pc+2:])
-		n = 2 + NumCodesPackedWide(nargs)
+		args = NewWideOperands(1, nargs, codes[pc+2:])
+		n = 2 + NumCodesPackedWide(nargs+1)
 		//
 		return
 	}
@@ -148,8 +155,14 @@ func DecodeEnter_n(pc uint32, codes []uint32) (width uint16, target uint32, args
 // +-----------------------------------+
 //
 // Here, nrets determines the number of packed return registers.  The wide form
-// retains the header but packs the (now u16) return registers two per word.
+// moves nrets up a byte (leaving bits 8-15 clear, as for all wide forms) and
+// packs the (now u16) return registers two per word:
 //
+// +-----------------+--------+--------+
+// |      nrets      |  n/a   | opcode |
+// +-----------------+--------+--------+
+// |       ret1      |       ret0      |
+// +-----------------+-----------------+
 // ============================================================================
 
 // encodeLeave_n encodes the LEAVE (function exit) instruction, packing the
@@ -159,16 +172,16 @@ func encodeLeave_n(rets []RegisterId) []uint32 {
 		panic("too many call returns")
 	}
 	//
-	var nrets = uint32(len(rets)) << 8
+	var nrets = uint32(len(rets))
 	//
 	if IsWideRegisters(rets...) {
-		var codes = []uint32{nrets | LEAVE_n | WIDE}
+		var codes = []uint32{nrets<<16 | LEAVE_n | WIDE}
 		//
 		return append(codes, PackShortsIntoCodes(RegsAsShorts(rets))...)
 	}
 	//
 	var (
-		codes = []uint32{nrets | LEAVE_n}
+		codes = []uint32{nrets<<8 | LEAVE_n}
 		bytes = RegsAsBytes(rets)
 	)
 	//
@@ -177,14 +190,14 @@ func encodeLeave_n(rets []RegisterId) []uint32 {
 
 // DecodeLeave_n decodes the operands of a leave (function exit) instruction.
 func DecodeLeave_n(pc uint32, codes []uint32) (rets Operands, n uint32) {
-	var (
-		nrets = uint(codes[pc]>>8) & 0xffff
-	)
-	//
 	if IsWideForm(pc, codes) {
+		var nrets = uint(codes[pc] >> 16)
+		//
 		rets = NewWideOperands(0, nrets, codes[pc+1:])
 		n = 1 + NumCodesPackedWide(nrets)
 	} else {
+		var nrets = uint(codes[pc]>>8) & 0xffff
+		//
 		rets = NewOperands(0, nrets, codes[pc+1:])
 		n = 1 + NumCodesPackedSmall(nrets)
 	}

--- a/pkg/zkc/vm/internal/interpreter/encoding/cat.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/cat.go
@@ -51,7 +51,7 @@ func DecodeCat[W word.Word[W]](pc uint32, codes []uint32) (Bytecode[W], uint32) 
 // per word:
 //
 // +--------+--------+--------+--------+
-// |  nsrc  |  ntgt  |  n/a   | opcode |
+// |  nsrc  |  ntgt  |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       tgt1      |       tgt0      |
 // +-----------------+-----------------+
@@ -79,7 +79,7 @@ func encodeRegisterLists(opcode uint32, targets []RegisterId, sources []Register
 	)
 	//
 	if IsWideRegisters(regs...) {
-		var codes = []uint32{nsrc | ntgt | opcode | WIDE}
+		var codes = []uint32{nsrc | ntgt | wideRegisterListOpcode(opcode)<<8 | WIDE}
 		//
 		return append(codes, PackShortsIntoCodes(regs)...)
 	}
@@ -90,6 +90,21 @@ func encodeRegisterLists(opcode uint32, targets []RegisterId, sources []Register
 	)
 	//
 	return append(codes, PackBytesIntoCodes(bytes)...)
+}
+
+// wideRegisterListOpcode maps a register-list opcode (CAT, UINT_TO_FIELD or
+// FIELD_TO_UINT) to its wide counterpart.
+func wideRegisterListOpcode(opcode uint32) uint32 {
+	switch opcode {
+	case CAT:
+		return WIDE_CAT
+	case UINT_TO_FIELD:
+		return WIDE_UINT_TO_FIELD
+	case FIELD_TO_UINT:
+		return WIDE_FIELD_TO_UINT
+	default:
+		panic("unknown register-list opcode")
+	}
 }
 
 // DecodeRegisterLists decodes target and source register lists.

--- a/pkg/zkc/vm/internal/interpreter/encoding/cat.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/cat.go
@@ -39,16 +39,27 @@ func DecodeCat[W word.Word[W]](pc uint32, codes []uint32) (Bytecode[W], uint32) 
 //	31                                0
 //
 // +--------+--------+--------+--------+
-// |   n/a  |  nsrc  | ntgt   | opcode |
+// |  nsrc  |  ntgt  |  n/a   | opcode |
 // +--------+--------+--------+--------+
 // | tgt3   | tgt2   | tgt1   | tgt0   |
 // +--------+--------+--------+--------+
-// | ... packed source registers ...    |
-// +------------------------------------+
+// | ... packed source registers ...   |
+// +-----------------------------------+
 //
 // The first source and target are the least-significant limbs.  The wide form
 // retains the header but packs the (now u16) target and source registers two
-// per word.
+// per word:
+//
+// +--------+--------+--------+--------+
+// |  nsrc  |  ntgt  |  n/a   | opcode |
+// +--------+--------+--------+--------+
+// |       tgt1      |       tgt0      |
+// +-----------------+-----------------+
+// | ... packed source registers ...    |
+// +------------------------------------+
+//
+// This layout is shared by the UINT_TO_FIELD and FIELD_TO_UINT instructions
+// (see field_cast.go), which also encode via encodeRegisterLists.
 // ============================================================================
 
 // encodeRegisterLists encodes target and source register lists.
@@ -62,8 +73,8 @@ func encodeRegisterLists(opcode uint32, targets []RegisterId, sources []Register
 	}
 	//
 	var (
-		nsrc = uint32(len(sources)) << 16
-		ntgt = uint32(len(targets)) << 8
+		nsrc = uint32(len(sources)) << 24
+		ntgt = uint32(len(targets)) << 16
 		regs = append(RegsAsShorts(targets), RegsAsShorts(sources)...)
 	)
 	//
@@ -84,8 +95,8 @@ func encodeRegisterLists(opcode uint32, targets []RegisterId, sources []Register
 // DecodeRegisterLists decodes target and source register lists.
 func DecodeRegisterLists(pc uint32, codes []uint32) (targets, sources Operands, n uint32) {
 	var (
-		ntargets = uint((codes[pc] >> 8) & 0xff)
-		nsources = uint((codes[pc] >> 16) & 0xff)
+		ntargets = uint((codes[pc] >> 16) & 0xff)
+		nsources = uint((codes[pc] >> 24) & 0xff)
 	)
 	//
 	if IsWideForm(pc, codes) {

--- a/pkg/zkc/vm/internal/interpreter/encoding/checkcast.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/checkcast.go
@@ -30,7 +30,7 @@ import (
 // width.  The wide form moves the (now u16) register into a subsequent word:
 //
 // +--------+--------+--------+--------+
-// |    bitwidth     |  n/a   | opcode |
+// |    bitwidth     |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       n/a       |        rd       |
 // +-----------------+-----------------+
@@ -43,7 +43,7 @@ func CheckCast[W word.Word[W]](p *bytecode.CheckCast[W]) []uint32 {
 	//
 	if IsWideRegisters(p.Target) {
 		return []uint32{
-			bitwidth | CHECKCAST | WIDE,
+			bitwidth | WIDE_CHECKCAST<<8 | WIDE,
 			uint32(p.Target),
 		}
 	}

--- a/pkg/zkc/vm/internal/interpreter/encoding/common.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/common.go
@@ -63,7 +63,9 @@ const OPCODE_MASK = 0x3f
 // form keeps its non-register fields in the first instruction word exactly as
 // the narrow form does (where they still fit), whilst its register operands
 // move into subsequent words, packed two per word (least significant half
-// first) in the order they appear in the narrow encoding.
+// first) in the order they appear in the narrow encoding.  INVARIANT: every
+// wide form leaves bits 8-15 of its first word clear (n/a), reserving a
+// uniform spare byte adjacent to the opcode byte for future expansion.
 const WIDE = 0x40
 
 // BREAKPOINT is a modifier bit (bit 7 of the opcode byte) which, when set,
@@ -280,7 +282,7 @@ func Encode[W word.Word[W]](b Bytecode[W], pc uint32, env Environment[W]) []uint
 	case *bytecode.Fail[W]:
 		return Fail(b, env)
 	case *bytecode.FieldArith[W]:
-		return FieldArith(b)
+		return FieldArith(b, env)
 	case *bytecode.UintToField[W]:
 		return UintToField(b)
 	case *bytecode.FieldToUint[W]:
@@ -296,9 +298,9 @@ func Encode[W word.Word[W]](b Bytecode[W], pc uint32, env Environment[W]) []uint
 	case *bytecode.Ret[W]:
 		return Ret(b, env)
 	case *bytecode.Switch[W]:
-		return Switch(b, env)
+		return Switch(pc, b, env)
 	case *bytecode.Dispatch[W]:
-		return Dispatch(b, env)
+		return Dispatch(pc, b, env)
 	default:
 		panic(fmt.Sprintf("unknown instruction encountered (%s)", b.String(nil)))
 	}
@@ -314,8 +316,17 @@ func MaxEncodedLength[W word.Word[W]](b bytecode.Bytecode[W], env Environment[W]
 	case *bytecode.Skip[W], *bytecode.Jmp[W]:
 		return 1
 	case *bytecode.Dispatch[W]:
-		// word 0 plus one (bit, target) pair per case.
-		return uint(1 + 2*len(b.Cases))
+		// word 0 plus one (skip, bit) word per case.  NOTE: an explicit case
+		// is required (rather than falling through to Encode below) because
+		// the case skips are relative, and hence cannot be computed at a
+		// placeholder position.
+		return uint(1 + len(b.Cases))
+	case *bytecode.Switch[W]:
+		// word 0 plus one (skip, cid) word per case.  NOTE: an explicit case
+		// is required (rather than falling through to Encode below) because
+		// the case skips are relative, and hence cannot be computed at a
+		// placeholder position.
+		return uint(1 + len(b.Cases))
 	case *bytecode.SkipIf[W]:
 		if b.Right.IsRegisterVector() {
 			// The wide form carries its base registers in an additional word.
@@ -325,30 +336,11 @@ func MaxEncodedLength[W word.Word[W]](b bytecode.Bytecode[W], env Environment[W]
 			//
 			return 2
 		}
-		// Constant form: the constant vector follows inline, one element per
-		// comparison element, each as a fixed number of 32-bit limbs.
-		// Normalisation (see SkipIf) can rewrite the constant to c+1, which
-		// may need one more bit — hence BitLen()+1 below.  An empty (or
-		// short) constant vector denotes zero (extension).
-		var (
-			nv   = uint(b.Left.Len)
-			bits uint
-		)
-		//
-		for _, c := range b.Right.AsConstants() {
-			bits = max(bits, c.BitLen())
-		}
-		//
-		var nlimbs = max(1, (bits+1+31)/32)
-		// NOTE: this bounds both the compact single-constant form (1+nc
-		// words) and the constant-vector form it falls back to (2+nc words,
-		// or 3+nc wide) when the skip exceeds a byte.  The wide vector form
-		// carries its base register in an additional word.
-		if IsWideRegisters(b.Left.Base) {
-			return 3 + nv*nlimbs
-		}
-		//
-		return 2 + nv*nlimbs
+		// Constant form: bounded by the general (WIDE) constant-vector
+		// fallback, which carries its register vector and constant vector in
+		// words of their own.  The compact forms (single-word SXX_rc and
+		// two-word SXX_rcv) are always smaller.
+		return 3
 	default:
 		// NOTE: the maximum length of the remaining bytecodes is not dependent
 		// on this position within the encoded sequence.

--- a/pkg/zkc/vm/internal/interpreter/encoding/common.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/common.go
@@ -45,40 +45,37 @@ type RegisterVector = bytecode.RegisterVector
 // OPCODE_MASK is used to extract the actual opcode from the opcode byte.  The
 // current format of an opcode byte is:
 //
-//	7   6   5                   0
+//	7   6                       0
 //
 // +---+---+---+---+---+---+---+---+
-// | B | W |        OPCODE         |
+// | B |          OPCODE           |
 // +---+---+---+---+---+---+---+---+
 //
-// Here, B is the Breakpoint flag, W is the Wide instruction flag, whilst the
-// lower 6-bits form the opcode itself.  For reference, the breakpoint bit
-// signals a breakpoint should be triggered immediately before the current
-// instruction executes.
-const OPCODE_MASK = 0x3f
-
-// WIDE is a modifier bit (bit 6 of the opcode byte) marking the "wide" form of
-// an instruction, whose register operands are u16 rather than u8.  Wide forms
-// arise for functions with more than 256 registers.  By convention, a wide
-// form keeps its non-register fields in the first instruction word exactly as
-// the narrow form does (where they still fit), whilst its register operands
-// move into subsequent words, packed two per word (least significant half
-// first) in the order they appear in the narrow encoding.  INVARIANT: every
-// wide form leaves bits 8-15 of its first word clear (n/a), reserving a
-// uniform spare byte adjacent to the opcode byte for future expansion.
-const WIDE = 0x40
+// Here, B is the Breakpoint flag, whilst the lower 7-bits form the opcode
+// itself.  For reference, the breakpoint bit signals a breakpoint should be
+// triggered immediately before the current instruction executes.
+const OPCODE_MASK = 0x7f
 
 // BREAKPOINT is a modifier bit (bit 7 of the opcode byte) which, when set,
 // signals that a breakpoint should be triggered immediately before the
-// instruction executes.  Like WIDE, it lies above the opcode field, so dispatch
-// (which masks with OPCODE_MASK) is unaffected and both flagged and unflagged
+// instruction executes.  It lies above the opcode field, so dispatch (which
+// masks with OPCODE_MASK) is unaffected and both flagged and unflagged
 // instructions reach the same executor.
 const BREAKPOINT = 0x80
 
-// IsWideForm checks whether the instruction word at the given position has the
-// WIDE modifier bit set (i.e. carries u16 register operands).
+// WIDE is a distinguished escape opcode (the top of the 7-bit opcode space)
+// signalling a "wide encoding".  For instructions dispatched this way, the
+// second byte of the first word (bits 8-15, which every wide form reserves)
+// holds the wide opcode itself (see the wide opcode enumeration below),
+// giving wide instructions an 8-bit opcode space of their own.  NOTE: when
+// the breakpoint flag is also set, the full first byte reads 0xFF.
+const WIDE = 0x7f
+
+// IsWideForm checks whether the instruction at the given position is a wide
+// form (i.e. carries u16 register operands), which holds exactly when its
+// opcode is the WIDE escape.
 func IsWideForm(pc uint32, codes []uint32) bool {
-	return codes[pc]&WIDE != 0
+	return codes[pc]&OPCODE_MASK == WIDE
 }
 
 // IsWideRegisters checks whether any of the given registers requires the wide
@@ -106,17 +103,9 @@ func IsWideRegisterVectors(vecs []RegisterVector) bool {
 	return false
 }
 
-// Every instruction occupies 32 bits, where the first byte is as follows:
-//
-//	7   6 5       0
-//
-// +-----+---------+
-// | : : | : : : : |
-// +-----+---------+
-//
-//	(n)   (opcode)
-//
-// Currently, n is instruction specific.
+// Every instruction occupies one or more 32-bit words, where the first byte
+// of the first word holds the breakpoint flag (bit 7) above the 7-bit opcode
+// (bits 0-6), as described for OPCODE_MASK above.
 const (
 	// FAIL instruction
 	FAIL uint32 = iota
@@ -256,6 +245,131 @@ const (
 	MAX_BYTECODE
 )
 
+// The following enumerate the "wide opcodes", which occupy a separate 8-bit
+// opcode space of their own: instructions encoded this way carry the WIDE
+// escape opcode in the first byte of their first word, with the wide opcode
+// itself in the second byte (bits 8-15) -- the byte which every wide form
+// reserves.  Each WIDE_XX opcode is the wide form of the corresponding XX
+// opcode, whose register operands are u16 rather than u8.  Wide forms arise
+// for functions with more than 256 registers.  By convention, a wide form
+// keeps its non-register fields in the first instruction word exactly as the
+// narrow form does (where they still fit), whilst its register operands move
+// into subsequent words, packed two per word (least significant half first)
+// in the order they appear in the narrow encoding.  NOTE: family contiguity
+// mirrors the narrow opcodes (e.g. WIDE_SUB_2n1 must follow WIDE_ADD_2n1),
+// since encoders and decoders compute wide opcodes by offset from the family
+// base.
+const (
+	// WIDE_FAIL instruction
+	WIDE_FAIL uint32 = iota
+	// WIDE_CHECKCAST instruction
+	WIDE_CHECKCAST
+	// WIDE_SEQ_rr (skip forward if equal)
+	WIDE_SEQ_rr
+	// WIDE_SNE_rr (skip forward if not equal)
+	WIDE_SNE_rr
+	// WIDE_SLT_rr (skip forward if less than)
+	WIDE_SLT_rr
+	// WIDE_SGE_rr (skip forward if greater than or equal)
+	WIDE_SGE_rr
+	// WIDE_SEQ_rv (skip forward if equal)
+	WIDE_SEQ_rv
+	// WIDE_SNE_rv (skip forward if not equal)
+	WIDE_SNE_rv
+	// WIDE_SLT_rv (skip forward if less than)
+	WIDE_SLT_rv
+	// WIDE_SGE_rv (skip forward if greater than or equal)
+	WIDE_SGE_rv
+	// WIDE_SEQ_rcv (skip forward if vector equal to constant vector)
+	WIDE_SEQ_rcv
+	// WIDE_SNE_rcv (skip forward if vector not equal to constant vector)
+	WIDE_SNE_rcv
+	// WIDE_SLT_rcv (skip forward if vector less than constant vector)
+	WIDE_SLT_rcv
+	// WIDE_SGE_rcv (skip forward if vector greater than or equal to constant
+	// vector)
+	WIDE_SGE_rcv
+	// WIDE_ENTER_n instruction
+	WIDE_ENTER_n
+	// WIDE_LEAVE_n instruction
+	WIDE_LEAVE_n
+	// WIDE_RET instruction
+	WIDE_RET
+	// WIDE_RD_ROM_nm instruction
+	WIDE_RD_ROM_nm
+	// WIDE_RD_SROM_nm instruction
+	WIDE_RD_SROM_nm
+	// WIDE_WR_WOM_nm instruction
+	WIDE_WR_WOM_nm
+	// WIDE_RD_RAM_nm instruction
+	WIDE_RD_RAM_nm
+	// WIDE_WR_RAM_nm instruction
+	WIDE_WR_RAM_nm
+	// WIDE_RD_PRAM_nm instruction
+	WIDE_RD_PRAM_nm
+	// WIDE_WR_PRAM_nm instruction
+	WIDE_WR_PRAM_nm
+	// WIDE_MOVE instruction
+	WIDE_MOVE
+	// WIDE_LDC_w (load wide constant) instruction
+	WIDE_LDC_w
+	// WIDE_UINT_TO_FIELD instruction
+	WIDE_UINT_TO_FIELD
+	// WIDE_ADD_2n1 instruction
+	WIDE_ADD_2n1
+	// WIDE_SUB_2n1 instruction [must follow WIDE_ADD_2n1]
+	WIDE_SUB_2n1
+	// WIDE_MUL_2n1 instruction [must follow WIDE_SUB_2n1]
+	WIDE_MUL_2n1
+	// WIDE_ADDC (add with constant) instruction
+	WIDE_ADDC
+	// WIDE_SUBC (subtract with constant) instruction
+	WIDE_SUBC
+	// WIDE_MULC (multiply with constant) instruction
+	WIDE_MULC
+	// WIDE_ADD_nm (addition with vector target) instruction
+	WIDE_ADD_nm
+	// WIDE_SUB_nm (subtraction with vector target) instruction [must follow
+	// WIDE_ADD_nm]
+	WIDE_SUB_nm
+	// WIDE_MUL_nm (multiplication with vector target) instruction [must
+	// follow WIDE_SUB_nm]
+	WIDE_MUL_nm
+	// WIDE_DIV instruction
+	WIDE_DIV
+	// WIDE_REM instruction [must follow WIDE_DIV]
+	WIDE_REM
+	// WIDE_INTRINSIC instruction
+	WIDE_INTRINSIC
+	// WIDE_ADDMOD_P instruction
+	WIDE_ADDMOD_P
+	// WIDE_SUBMOD_P instruction
+	WIDE_SUBMOD_P
+	// WIDE_MULMOD_P instruction
+	WIDE_MULMOD_P
+	// WIDE_AND instruction
+	WIDE_AND
+	// WIDE_OR instruction
+	WIDE_OR
+	// WIDE_XOR instruction
+	WIDE_XOR
+	// WIDE_NOT instruction
+	WIDE_NOT
+	// WIDE_SHL instruction
+	WIDE_SHL
+	// WIDE_SHR instruction
+	WIDE_SHR
+	// WIDE_CAT instruction
+	WIDE_CAT
+	// WIDE_DEBUG instruction
+	WIDE_DEBUG
+	// WIDE_FIELD_TO_UINT instruction
+	WIDE_FIELD_TO_UINT
+
+	//
+	MAX_WIDE_BYTECODE
+)
+
 // Encode encodes the given bytecode into its sequence of 32-bit instruction
 // words.  Here, pc is the address at which the instruction will reside within
 // the compiled sequence (needed to compute relative branch offsets), whilst env
@@ -336,7 +450,7 @@ func MaxEncodedLength[W word.Word[W]](b bytecode.Bytecode[W], env Environment[W]
 			//
 			return 2
 		}
-		// Constant form: bounded by the general (WIDE) constant-vector
+		// Constant form: bounded by the general (wide) constant-vector
 		// fallback, which carries its register vector and constant vector in
 		// words of their own.  The compact forms (single-word SXX_rc and
 		// two-word SXX_rcv) are always smaller.
@@ -536,7 +650,13 @@ func RegisterVectorsAsShorts(vecs []RegisterVector) []uint16 {
 }
 
 func init() {
-	if MAX_BYTECODE > OPCODE_MASK+1 {
+	// NOTE: the WIDE escape occupies the top of the (7-bit) opcode space, so
+	// regular opcodes must stay strictly below it.
+	if MAX_BYTECODE > WIDE {
 		panic("overflowing opcodes")
+	}
+	// The wide opcode space is a single byte.
+	if MAX_WIDE_BYTECODE > 256 {
+		panic("overflowing wide opcodes")
 	}
 }

--- a/pkg/zkc/vm/internal/interpreter/encoding/debug.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/debug.go
@@ -51,8 +51,18 @@ func DecodeDebug(pc uint32, codes []uint32) (index uint, sources Operands, n uin
 // Here, nvecs determines the number of packed source register vectors, whilst
 // index identifies the formatted chunks (i.e. the debug message template) to
 // emit.  Each source vector is encoded as a (base, len) byte pair, packed two
-// vectors per word.  The wide form retains the header but packs each vector as
-// a (base, len) pair of u16 operands (i.e. one word per vector).
+// vectors per word.  The wide form moves the index into a word of its own
+// (leaving bits 8-23 of the first word clear, as for all wide forms) and
+// packs each vector as a (base, len) pair of u16 operands (i.e. one word per
+// vector):
+//
+// +--------+--------+--------+--------+
+// |  nvecs |       n/a       | opcode |
+// +--------+--------+--------+--------+
+// |       n/a       |      index      |
+// +-----------------+-----------------+
+// |       len0      |      base0      |
+// +-----------------+-----------------+
 // ============================================================================
 
 // encodeDebug_n encodes a debug instruction referencing the formatted chunks at
@@ -61,7 +71,7 @@ func encodeDebug_n(index uint16, sources []RegisterVector) []uint32 {
 	var nsources = uint32(util.Cast[uint8](uint(len(sources)))) << 24
 	//
 	if IsWideRegisterVectors(sources) {
-		var codes = []uint32{nsources | uint32(index)<<8 | DEBUG | WIDE}
+		var codes = []uint32{nsources | DEBUG | WIDE, uint32(index)}
 		//
 		return append(codes, PackShortsIntoCodes(RegisterVectorsAsShorts(sources))...)
 	}
@@ -78,12 +88,12 @@ func encodeDebug_n(index uint16, sources []RegisterVector) []uint32 {
 func decodeDebug_n(pc uint32, codes []uint32) (index uint, sources Operands, n uint32) {
 	var nops = 2 * uint(codes[pc]>>24)
 	//
-	index = uint(codes[pc]>>8) & 0xffff
-	//
 	if IsWideForm(pc, codes) {
-		sources = NewWideOperands(0, nops, codes[pc+1:])
-		n = 1 + NumCodesPackedWide(nops)
+		index = uint(codes[pc+1]) & 0xffff
+		sources = NewWideOperands(0, nops, codes[pc+2:])
+		n = 2 + NumCodesPackedWide(nops)
 	} else {
+		index = uint(codes[pc]>>8) & 0xffff
 		sources = NewOperands(0, nops, codes[pc+1:])
 		n = 1 + NumCodesPackedSmall(nops)
 	}

--- a/pkg/zkc/vm/internal/interpreter/encoding/debug.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/debug.go
@@ -57,7 +57,7 @@ func DecodeDebug(pc uint32, codes []uint32) (index uint, sources Operands, n uin
 // vector):
 //
 // +--------+--------+--------+--------+
-// |  nvecs |       n/a       | opcode |
+// |  nvecs |  n/a   |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       n/a       |      index      |
 // +-----------------+-----------------+
@@ -71,7 +71,7 @@ func encodeDebug_n(index uint16, sources []RegisterVector) []uint32 {
 	var nsources = uint32(util.Cast[uint8](uint(len(sources)))) << 24
 	//
 	if IsWideRegisterVectors(sources) {
-		var codes = []uint32{nsources | DEBUG | WIDE, uint32(index)}
+		var codes = []uint32{nsources | WIDE_DEBUG<<8 | WIDE, uint32(index)}
 		//
 		return append(codes, PackShortsIntoCodes(RegisterVectorsAsShorts(sources))...)
 	}

--- a/pkg/zkc/vm/internal/interpreter/encoding/dispatch.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/dispatch.go
@@ -28,45 +28,46 @@ import (
 // +--------+--------+--------+--------+
 // |  count |    default      | opcode |
 // +--------+--------+--------+--------+
-// |          case 0: bit              |
-// +-----------------------------------+
-// |          case 0: target           |
-// +-----------------------------------+
+// |  case 0: skip   |  case 0: bit    |
+// +-----------------+-----------------+
 // |                ...                |
-// +-----------------------------------+
-// |       case count-1: bit           |
-// +-----------------------------------+
-// |       case count-1: target        |
-// +-----------------------------------+
+// +-----------------+-----------------+
+// |  count-1: skip  |  count-1: bit   |
+// +-----------------+-----------------+
 //
 // Here, default identifies the (1-bit) register holding the sum of the case
-// bits, and count gives the number of (bit, target) cases which follow.  Each
-// case is encoded as a bit register identifier followed by an absolute u32
-// target address.  Control transfers to the target of the first case whose bit
-// register is set; when no bit is set, control falls through past the whole
-// instruction.
+// bits, and count gives the number of cases which follow, one word each.  Each
+// case is encoded as a u16 bit register identifier together with an unsigned
+// u16 relative skip offset (where the following instruction is considered to
+// be at offset 0, as for the other skip forms).  Control skips forward to the
+// target of the first case whose bit register is set; when no bit is set,
+// control falls through past the whole instruction.  There is no encoding for
+// a skip exceeding u16 (encoding panics instead).
 // ============================================================================
 
 // Dispatch encodes a one-hot dispatch bytecode, which dispatches over a table
-// of (bit register, target) pairs.
-func Dispatch[W word.Word[W]](p *bytecode.Dispatch[W], env Environment[W]) []uint32 {
+// of (bit register, skip) pairs.
+func Dispatch[W word.Word[W]](pc Address, p *bytecode.Dispatch[W], env Environment[W]) []uint32 {
 	// count occupies a single byte (bits 24..31) of word 0.
 	if len(p.Cases) > math.MaxUint8 {
 		panic("too many cases in one-hot dispatch")
 	}
 	// word 0: count | default | opcode
 	var codes = []uint32{uint32(len(p.Cases))<<24 | uint32(p.Default)<<8 | SKIP_B}
-	// Append one (bit, target) pair per case.
+	// Append one (skip, bit) word per case.
 	for _, c := range p.Cases {
 		var (
 			// Resolve this case's target program point, ...
 			target = env.Point().Skip(uint(c.Skip))
-			// ... then its absolute offset in the encoded sequence (SKIP_B
-			// targets are absolute, unlike the relative SKIP/JMP forms).
-			offset = env.OffsetFor(env.enclosing, target)
+			// ... then its relative offset from the following instruction.
+			skip = env.OffsetFor(env.enclosing, target) - (pc + 1)
 		)
 		//
-		codes = append(codes, uint32(c.Bit), offset)
+		if skip > math.MaxUint16 {
+			panic("skip exceeds one-hot dispatch form")
+		}
+		//
+		codes = append(codes, skip<<16|uint32(c.Bit))
 	}
 	//
 	return codes

--- a/pkg/zkc/vm/internal/interpreter/encoding/div.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/div.go
@@ -115,14 +115,25 @@ func DecodeDivRem_2n1(pc uint32, codes []uint32) (rd, dividend, divisor Register
 // +--------+--------+--------+--------+
 // |   op   |  nsrc  |  ntgt  | opcode |
 // +--------+--------+--------+--------+
-// | ... packed target then source register vectors ... |
-// +-----------------------------------------------------+
+// | ... packed tgt/src reg vectors .. |
+// +-----------------------------------+
 //
 // Here, op selects the hint operation (e.g. DIV_HINT), whilst ntgt and nsrc give
 // the number of target (return) and source (argument) register vectors
 // respectively.  Each vector is packed as a (base, len) byte pair, targets
-// first.  The wide form retains the header but packs each vector as a (base,
-// len) pair of u16 operands (i.e. one word per vector).
+// first.  The wide form moves the target count into the first packed slot
+// (leaving bits 8-15 of the first word clear, as for all wide forms), with
+// each vector following as a (base, len) pair of u16 operands:
+//
+// +--------+--------+--------+--------+
+// |   op   |  nsrc  |  n/a   | opcode |
+// +--------+--------+--------+--------+
+// |    tgt0 base    |      ntgt       |
+// +-----------------+-----------------+
+// |    tgt1 base    |    tgt0 len     |
+// +-----------------+-----------------+
+// | ... packed tgt/src reg vectors .. |
+// +-----------------------------------+
 // ============================================================================
 
 // encodeIntrinsic encodes a hint instruction, where op selects the operation and the
@@ -141,9 +152,14 @@ func encodeIntrinsic(op Operation, targets, sources []RegisterVector) []uint32 {
 	//
 	if IsWideRegisterVectors(targets) || IsWideRegisterVectors(sources) {
 		var (
-			codes  = []uint32{nop | nsrc | ntgt | INTRINSIC | WIDE}
-			shorts = append(RegisterVectorsAsShorts(targets), RegisterVectorsAsShorts(sources)...)
+			codes = []uint32{nop | nsrc | INTRINSIC | WIDE}
+			// ntgt occupies the first packed slot, followed by the vectors.
+			shorts = make([]uint16, 0, 1+2*(len(targets)+len(sources)))
 		)
+		//
+		shorts = append(shorts, uint16(len(targets)))
+		shorts = append(shorts, RegisterVectorsAsShorts(targets)...)
+		shorts = append(shorts, RegisterVectorsAsShorts(sources)...)
 		//
 		return append(codes, PackShortsIntoCodes(shorts)...)
 	}
@@ -160,18 +176,19 @@ func encodeIntrinsic(op Operation, targets, sources []RegisterVector) []uint32 {
 // source operands of a hint instruction.  Each vector is packed as a (base,
 // len) byte pair, hence the iterators range over twice the vector counts.
 func DecodeIntrinsicOperands(pc uint32, codes []uint32) (op Operation, targets, sources Operands, n uint32) {
-	var (
-		ntargets = uint((codes[pc] >> 8) & 0xff)
-		nsources = uint((codes[pc] >> 16) & 0xff)
-	)
+	var nsources = uint((codes[pc] >> 16) & 0xff)
 	//
 	op = Operation((codes[pc] >> 24) & 0xff)
 	//
 	if IsWideForm(pc, codes) {
-		targets = NewWideOperands(0, 2*ntargets, codes[pc+1:])
-		sources = NewWideOperands(2*ntargets, 2*nsources, codes[pc+1:])
-		n = 1 + NumCodesPackedWide(2*(ntargets+nsources))
+		var ntargets = uint(codes[pc+1] & 0xffff)
+		//
+		targets = NewWideOperands(1, 2*ntargets, codes[pc+1:])
+		sources = NewWideOperands(1+(2*ntargets), 2*nsources, codes[pc+1:])
+		n = 1 + NumCodesPackedWide(1+2*(ntargets+nsources))
 	} else {
+		var ntargets = uint((codes[pc] >> 8) & 0xff)
+		//
 		targets = NewOperands(0, 2*ntargets, codes[pc+1:])
 		sources = NewOperands(2*ntargets, 2*nsources, codes[pc+1:])
 		n = 1 + NumCodesPackedSmall(2*(ntargets+nsources))

--- a/pkg/zkc/vm/internal/interpreter/encoding/div.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/div.go
@@ -71,7 +71,7 @@ func registerVectorsFromIter(iter Operands) []RegisterVector {
 // with both source registers in a second:
 //
 // +--------+--------+--------+--------+
-// |        rd       |  n/a   | opcode |
+// |        rd       |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |     divisor     |    dividend     |
 // +-----------------+-----------------+
@@ -82,7 +82,7 @@ func registerVectorsFromIter(iter Operands) []RegisterVector {
 func encodeDivRem(op uint32, rd, dividend, divisor RegisterId) []uint32 {
 	if IsWideRegisters(rd, dividend, divisor) {
 		return []uint32{
-			uint32(rd)<<16 | op | WIDE,
+			uint32(rd)<<16 | (WIDE_DIV+(op-DIV))<<8 | WIDE,
 			uint32(dividend) | uint32(divisor)<<16,
 		}
 	}
@@ -126,7 +126,7 @@ func DecodeDivRem_2n1(pc uint32, codes []uint32) (rd, dividend, divisor Register
 // each vector following as a (base, len) pair of u16 operands:
 //
 // +--------+--------+--------+--------+
-// |   op   |  nsrc  |  n/a   | opcode |
+// |   op   |  nsrc  |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |    tgt0 base    |      ntgt       |
 // +-----------------+-----------------+
@@ -152,7 +152,7 @@ func encodeIntrinsic(op Operation, targets, sources []RegisterVector) []uint32 {
 	//
 	if IsWideRegisterVectors(targets) || IsWideRegisterVectors(sources) {
 		var (
-			codes = []uint32{nop | nsrc | INTRINSIC | WIDE}
+			codes = []uint32{nop | nsrc | WIDE_INTRINSIC<<8 | WIDE}
 			// ntgt occupies the first packed slot, followed by the vectors.
 			shorts = make([]uint16, 0, 1+2*(len(targets)+len(sources)))
 		)

--- a/pkg/zkc/vm/internal/interpreter/encoding/environment.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/environment.go
@@ -14,6 +14,8 @@ package encoding
 
 import (
 	"fmt"
+	"math"
+	"strings"
 
 	"github.com/LFDT-Lineth/zkc/pkg/util/collection/array"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/bytecode"
@@ -93,6 +95,17 @@ type SymbolTable[W word.Word[W]] struct {
 	// chunks holds formatted chunks referenced (by index) from certain
 	// instructions, such as failures and debug statements.
 	chunks [][]bytecode.FormattedChunk
+	// constants is the constant pool: words referenced (by index) from
+	// instructions whose constant operand does not fit inline, in place of the
+	// constant itself.
+	constants []W
+	// cindex indexes the constant pool for interning, keyed on the constant's
+	// (big-endian) byte representation.
+	cindex map[string]uint16
+	// cvindex indexes consecutive runs of pool entries for interning constant
+	// vectors, keyed on the (length-prefixed) byte representations of their
+	// elements and mapping to the pool index of the first element.
+	cvindex map[string]uint16
 	// mapping maps either: (i) labels to their bytecode addresses; (ii)
 	// memories to their memory-specific identifiers.  This allows one, for
 	// example, to determine the starting address of a function.
@@ -102,7 +115,11 @@ type SymbolTable[W word.Word[W]] struct {
 // NewSymbolTable constructs an (initially empty) symbol table for the given
 // modules.
 func NewSymbolTable[W word.Word[W]](modules ...descriptor.Module[W]) SymbolTable[W] {
-	return SymbolTable[W]{modules, nil, make(map[Label]Symbol)}
+	return SymbolTable[W]{
+		modules, nil, nil,
+		make(map[string]uint16), make(map[string]uint16),
+		make(map[Label]Symbol),
+	}
 }
 
 // ChunksIndex returns the index identifying the given sequence of formatted
@@ -121,6 +138,78 @@ func (p *SymbolTable[W]) ChunksIndex(chunks ...bytecode.FormattedChunk) uint {
 	p.chunks = append(p.chunks, chunks)
 	//
 	return n
+}
+
+// ConstantIndex returns the constant pool index identifying the given
+// constant, interning it on first use.  That is, if an identical constant has
+// been seen before its existing index is returned; otherwise, the constant is
+// stored and a fresh index allocated.  Interning is idempotent, which matters
+// because encoding runs several times whilst the layout reaches a fixpoint.
+func (p *SymbolTable[W]) ConstantIndex(constant W) uint16 {
+	var key = string(constant.BigInt().Bytes())
+	//
+	if index, ok := p.cindex[key]; ok {
+		return index
+	}
+	// Sanity check pool capacity, since indices are encoded as u16.
+	if len(p.constants) > math.MaxUint16 {
+		panic(fmt.Sprintf("too many constant pool entries (%d)", len(p.constants)))
+	}
+	// Allocate new constant
+	var index = uint16(len(p.constants))
+	//
+	p.constants = append(p.constants, constant)
+	p.cindex[key] = index
+	//
+	return index
+}
+
+// ConstantVectorIndex returns the constant pool index of the first element of
+// the given constant vector, interning the whole vector as a consecutive run
+// of pool entries on first use.  That is, element i of the vector resides at
+// pool index ConstantVectorIndex(v)+i.  As for ConstantIndex, interning is
+// idempotent.
+func (p *SymbolTable[W]) ConstantVectorIndex(constants []W) uint16 {
+	var sb strings.Builder
+	// NOTE: elements are length-prefixed to keep the key unambiguous.
+	for _, c := range constants {
+		var bytes = c.BigInt().Bytes()
+		//
+		sb.WriteByte(byte(len(bytes) >> 8))
+		sb.WriteByte(byte(len(bytes)))
+		sb.Write(bytes)
+	}
+	//
+	var key = sb.String()
+	//
+	if index, ok := p.cvindex[key]; ok {
+		return index
+	}
+	// Sanity check pool capacity, since indices are encoded as u16.
+	if len(p.constants)+len(constants) > math.MaxUint16+1 {
+		panic(fmt.Sprintf("too many constant pool entries (%d)", len(p.constants)+len(constants)))
+	}
+	// Allocate new (consecutive) run of constants.
+	var index = uint16(len(p.constants))
+	//
+	p.constants = append(p.constants, constants...)
+	p.cvindex[key] = index
+	// Record any element not already interned individually, allowing
+	// subsequent singleton lookups to reuse this run's entries.
+	for i, c := range constants {
+		var ckey = string(c.BigInt().Bytes())
+		//
+		if _, ok := p.cindex[ckey]; !ok {
+			p.cindex[ckey] = index + uint16(i)
+		}
+	}
+	//
+	return index
+}
+
+// Constants returns the constant pool.
+func (p *SymbolTable[W]) Constants() []W {
+	return p.constants
 }
 
 // EnvironmentFor returns an Environment which views this symbol table from the

--- a/pkg/zkc/vm/internal/interpreter/encoding/fail.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/fail.go
@@ -49,13 +49,13 @@ func DecodeFail(pc uint32, codes []uint32) (index uint, sources Operands, n uint
 // Here, nvecs determines the number of packed source register vectors, whilst
 // index identifies the formatted chunks (i.e. the failure message template) to
 // emit.  Each source vector is encoded as a (base, len) byte pair, packed two
-// vectors per word.  The wide form moves the index into a word of its own
-// (leaving bits 8-23 of the first word clear, as for all wide forms) and
-// packs each vector as a (base, len) pair of u16 operands (i.e. one word per
-// vector):
+// vectors per word.  The wide form is dispatched via the WIDE escape opcode,
+// carrying its wide opcode (WIDE_FAIL) in the second byte; the index moves
+// into a word of its own, with each vector packed as a (base, len) pair of
+// u16 operands (i.e. one word per vector):
 //
 // +--------+--------+--------+--------+
-// |  nvecs |       n/a       | opcode |
+// |  nvecs |  n/a   |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       n/a       |      index      |
 // +-----------------+-----------------+
@@ -68,8 +68,7 @@ func encodeFail_n(index uint16, sources []RegisterVector) []uint32 {
 	var nsources = uint32(util.Cast[uint8](uint(len(sources)))) << 24
 	//
 	if IsWideRegisterVectors(sources) {
-		// nolint
-		var codes = []uint32{nsources | FAIL | WIDE, uint32(index)}
+		var codes = []uint32{nsources | WIDE_FAIL<<8 | WIDE, uint32(index)}
 		//
 		return append(codes, PackShortsIntoCodes(RegisterVectorsAsShorts(sources))...)
 	}

--- a/pkg/zkc/vm/internal/interpreter/encoding/fail.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/fail.go
@@ -49,8 +49,18 @@ func DecodeFail(pc uint32, codes []uint32) (index uint, sources Operands, n uint
 // Here, nvecs determines the number of packed source register vectors, whilst
 // index identifies the formatted chunks (i.e. the failure message template) to
 // emit.  Each source vector is encoded as a (base, len) byte pair, packed two
-// vectors per word.  The wide form retains the header but packs each vector as
-// a (base, len) pair of u16 operands (i.e. one word per vector).
+// vectors per word.  The wide form moves the index into a word of its own
+// (leaving bits 8-23 of the first word clear, as for all wide forms) and
+// packs each vector as a (base, len) pair of u16 operands (i.e. one word per
+// vector):
+//
+// +--------+--------+--------+--------+
+// |  nvecs |       n/a       | opcode |
+// +--------+--------+--------+--------+
+// |       n/a       |      index      |
+// +-----------------+-----------------+
+// |       len0      |      base0      |
+// +-----------------+-----------------+
 // ============================================================================
 // encodeFail_n encodes a fail instruction referencing the formatted chunks at
 // the given index, packing its source register vectors.
@@ -59,7 +69,7 @@ func encodeFail_n(index uint16, sources []RegisterVector) []uint32 {
 	//
 	if IsWideRegisterVectors(sources) {
 		// nolint
-		var codes = []uint32{nsources | uint32(index)<<8 | FAIL | WIDE}
+		var codes = []uint32{nsources | FAIL | WIDE, uint32(index)}
 		//
 		return append(codes, PackShortsIntoCodes(RegisterVectorsAsShorts(sources))...)
 	}
@@ -79,12 +89,12 @@ func encodeFail_n(index uint16, sources []RegisterVector) []uint32 {
 func decodeFail_n(pc uint32, codes []uint32) (index uint, sources Operands, n uint32) {
 	var nops = 2 * uint(codes[pc]>>24)
 	//
-	index = uint(codes[pc]>>8) & 0xffff
-	//
 	if IsWideForm(pc, codes) {
-		sources = NewWideOperands(0, nops, codes[pc+1:])
-		n = 1 + NumCodesPackedWide(nops)
+		index = uint(codes[pc+1]) & 0xffff
+		sources = NewWideOperands(0, nops, codes[pc+2:])
+		n = 2 + NumCodesPackedWide(nops)
 	} else {
+		index = uint(codes[pc]>>8) & 0xffff
 		sources = NewOperands(0, nops, codes[pc+1:])
 		n = 1 + NumCodesPackedSmall(nops)
 	}

--- a/pkg/zkc/vm/internal/interpreter/encoding/field.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/field.go
@@ -69,7 +69,7 @@ func DecodeFieldArithOperands[W word.Word[W]](pc uint32, codes []uint32, pool []
 // packs the source registers two per word:
 //
 // +--------+--------+--------+--------+
-// |  nsrc  |       n/a       | opcode |
+// |  nsrc  |  n/a   |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       cid       |        rd       |
 // +-----------------+-----------------+
@@ -106,7 +106,10 @@ func encodeFieldArith[W word.Word[W]](op bytecode.Operation, rd RegisterId, sour
 		return append(codes, PackBytesIntoCodes(RegsAsBytes(sources))...)
 	}
 	// Wide form: also the fallback when the pool identifier exceeds a byte.
-	var codes = []uint32{header | opcode | WIDE, cid<<16 | uint32(rd)}
+	var codes = []uint32{
+		header | (WIDE_ADDMOD_P+uint32(op-bytecode.OP_ADDMOD_P))<<8 | WIDE,
+		cid<<16 | uint32(rd),
+	}
 	//
 	return append(codes, PackShortsIntoCodes(RegsAsShorts(sources))...)
 }

--- a/pkg/zkc/vm/internal/interpreter/encoding/field.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/field.go
@@ -13,50 +13,36 @@
 package encoding
 
 import (
+	"math"
+
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/bytecode"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
 )
 
 // FieldArith encodes a field-arithmetic bytecode (ADDMOD_P/SUBMOD_P/MULMOD_P).
-func FieldArith[W word.Word[W]](p *bytecode.FieldArith[W]) []uint32 {
-	return encodeFieldArith(p.Op, p.Target, p.Sources, p.Constant)
+func FieldArith[W word.Word[W]](p *bytecode.FieldArith[W], env Environment[W]) []uint32 {
+	return encodeFieldArith(p.Op, p.Target, p.Sources, p.Constant, env)
 }
 
 // DecodeFieldArithOperands extracts the raw operands (target register, source
 // register iterator, constant and instruction width) of a field-arithmetic
 // instruction.  It is shared by the disassembler (DecodeFieldArith) and the
 // interpreter's executor.
-func DecodeFieldArithOperands[W word.Word[W]](pc uint32, codes []uint32) (
+func DecodeFieldArithOperands[W word.Word[W]](pc uint32, codes []uint32, pool []W) (
 	rd RegisterId, sources Operands, constant W, n uint32) {
 	//
-	var (
-		nlimbs = (codes[pc] >> 16) & 0xff
-		nsrc   = uint((codes[pc] >> 24) & 0xff)
-		wide   = IsWideForm(pc, codes)
-		offset = pc
-		limb   W
-	)
+	var nsrc = uint((codes[pc] >> 24) & 0xff)
 	//
-	if wide {
+	if IsWideForm(pc, codes) {
 		rd = RegisterId(codes[pc+1] & 0xffff)
-		offset = pc + 1
+		constant = pool[codes[pc+1]>>16]
+		sources = NewWideOperands(0, nsrc, codes[pc+2:])
+		n = 2 + NumCodesPackedWide(nsrc)
 	} else {
 		rd = RegisterId((codes[pc] >> 8) & 0xff)
-	}
-	// Reconstruct the constant from its 32-bit limbs, most significant limb
-	// first: each limb is shifted into the low bits of the accumulator in turn.
-	for i := nlimbs; i > 0; i-- {
-		limb = limb.SetUint64(uint64(codes[offset+i]))
-		_, constant = constant.Shl64(32)
-		constant = constant.Or(limb)
-	}
-	// Source registers follow the constant limbs.
-	if wide {
-		sources = NewWideOperands(0, nsrc, codes[offset+1+nlimbs:])
-		n = 2 + nlimbs + NumCodesPackedWide(nsrc)
-	} else {
-		sources = NewOperands(0, nsrc, codes[offset+1+nlimbs:])
-		n = 1 + nlimbs + NumCodesPackedSmall(nsrc)
+		constant = pool[(codes[pc]>>16)&0xff]
+		sources = NewOperands(0, nsrc, codes[pc+1:])
+		n = 1 + NumCodesPackedSmall(nsrc)
 	}
 	//
 	return rd, sources, constant, n
@@ -68,80 +54,59 @@ func DecodeFieldArithOperands[W word.Word[W]](pc uint32, codes []uint32) (
 //	31                                0
 //
 // +--------+--------+--------+--------+
-// |  nsrc  |  ncon  |   rd   | opcode |
+// |  nsrc  |  cid   |   rd   | opcode |
 // +--------+--------+--------+--------+
-// | constant limb 0 (least significant)|
-// +------------------------------------+
-// |                ...                 |
-// +------------------------------------+
-// | constant limb ncon-1 (most sig.)   |
-// +------------------------------------+
-// | ... packed source registers ...    |
-// +------------------------------------+
+// | ... packed source registers ...   |
+// +-----------------------------------+
 //
-// Here, rd is a u8 destination register, ncon is the number of 32-bit constant
-// limbs (carried inline, least significant first, as for LDC_w) and nsrc is the
-// number of source registers (packed four-per-code after the constant).  The
-// operation itself (add, subtract or multiply, modulo the prime) is identified
-// by the opcode.  A field-sized constant can be wider than the 64 bits carried
-// by the integer vector forms, hence the inline limb encoding.  The wide form
-// moves the (now u16) destination register into a word of its own, preceding
-// the constant limbs, and packs the source registers two per word:
+// Here, rd is a u8 destination register, cid is a u8 constant pool identifier
+// for the constant operand and nsrc is the number of source registers (packed
+// four-per-code).  The operation itself (add, subtract or multiply, modulo
+// the prime) is identified by the opcode.  A field-sized constant can be
+// wider than the 64 bits carried by the integer vector forms, which the pool
+// accommodates naturally.  The wide form moves the (now u16) destination
+// register and the (now u16) pool identifier into a subsequent word, and
+// packs the source registers two per word:
 //
 // +--------+--------+--------+--------+
-// |  nsrc  |  ncon  |  n/a   | opcode |
+// |  nsrc  |       n/a       | opcode |
 // +--------+--------+--------+--------+
-// |       n/a       |        rd       |
+// |       cid       |        rd       |
 // +-----------------+-----------------+
-// | ... constant limbs ...             |
-// +------------------------------------+
-// | ... packed source registers ...    |
-// +------------------------------------+
+// | ... packed source registers ...   |
+// +-----------------------------------+
+//
+// The wide form is also selected when the registers are small but the pool
+// identifier exceeds a byte.
 // ============================================================================
 
-// encodeFieldArith encodes a field-arithmetic instruction, carrying the
-// (possibly field-sized) constant inline as a sequence of 32-bit limbs followed
-// by the packed source registers.
-func encodeFieldArith[W word.Word[W]](op bytecode.Operation, rd RegisterId, sources []RegisterId, constant W) []uint32 {
+// encodeFieldArith encodes a field-arithmetic instruction, carrying its
+// (possibly field-sized) constant as a constant pool identifier followed by
+// the packed source registers.
+func encodeFieldArith[W word.Word[W]](op bytecode.Operation, rd RegisterId, sources []RegisterId, constant W,
+	env Environment[W]) []uint32 {
+	//
 	if len(sources) >= 256 {
 		panic("field instruction operand counts not supported")
 	}
 	//
 	var (
 		opcode = ADDMOD_P + uint32(op-bytecode.OP_ADDMOD_P)
-		// NOTE: big-endian byte ordering
-		bytes  = constant.BigInt().Bytes()
-		nlimbs = (len(bytes) + 3) / 4
 		wide   = IsWideRegisters(rd) || IsWideRegisters(sources...)
-		header = uint32(len(sources))<<24 | uint32(nlimbs)<<16
-		codes  []uint32
-		offset int
+		header = uint32(len(sources)) << 24
+		// NOTE: the pool identifier is stable across encoding passes
+		// (ConstantIndex interns), so the choice of form below cannot
+		// oscillate whilst the layout reaches a fixpoint.
+		cid = uint32(env.ConstantIndex(constant))
 	)
 	//
-	if nlimbs >= 256 {
-		panic("wide field constants not supported")
-	}
-	//
-	if wide {
-		codes = make([]uint32, nlimbs+2)
-		codes[0] = header | opcode | WIDE
-		codes[1] = uint32(rd)
-		offset = 2
-	} else {
-		codes = make([]uint32, nlimbs+1)
-		codes[0] = header | uint32(rd)<<8 | opcode
-		offset = 1
-	}
-	// Pack constant bytes into limbs, least significant limb first.
-	for i, b := range bytes {
-		var k = len(bytes) - 1 - i
+	if !wide && cid <= math.MaxUint8 {
+		var codes = []uint32{header | cid<<16 | uint32(rd)<<8 | opcode}
 		//
-		codes[offset+(k/4)] |= uint32(b) << (8 * (k % 4))
+		return append(codes, PackBytesIntoCodes(RegsAsBytes(sources))...)
 	}
-	// Append packed source registers.
-	if wide {
-		return append(codes, PackShortsIntoCodes(RegsAsShorts(sources))...)
-	}
+	// Wide form: also the fallback when the pool identifier exceeds a byte.
+	var codes = []uint32{header | opcode | WIDE, cid<<16 | uint32(rd)}
 	//
-	return append(codes, PackBytesIntoCodes(RegsAsBytes(sources))...)
+	return append(codes, PackShortsIntoCodes(RegsAsShorts(sources))...)
 }

--- a/pkg/zkc/vm/internal/interpreter/encoding/field_cast.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/field_cast.go
@@ -17,6 +17,35 @@ import (
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
 )
 
+// ============================================================================
+// UINT_TO_FIELD / FIELD_TO_UINT instruction.  Format of these instructions is
+// the register-list layout shared with CAT (see encodeRegisterLists):
+//
+//	31                                0
+//
+// +--------+--------+--------+--------+
+// |  nsrc  |  ntgt  |  n/a   | opcode |
+// +--------+--------+--------+--------+
+// | tgt3   | tgt2   | tgt1   | tgt0   |
+// +--------+--------+--------+--------+
+// | ... packed source registers ...   |
+// +-----------------------------------+
+//
+// For UINT_TO_FIELD there is a single target (the field register), with the
+// sources being the uint limbs (least significant first); conversely, for
+// FIELD_TO_UINT there is a single source (the field register), with the
+// targets being the uint limbs.  The wide form retains the header but packs
+// the (now u16) target and source registers two per word:
+//
+// +--------+--------+--------+--------+
+// |  nsrc  |  ntgt  |  n/a   | opcode |
+// +--------+--------+--------+--------+
+// |       tgt1      |       tgt0      |
+// +-----------------+-----------------+
+// | ... packed source registers ...   |
+// +-----------------------------------+
+// ============================================================================
+
 // UintToField encodes a uint-to-field conversion.
 func UintToField[W word.Word[W]](p *bytecode.UintToField[W]) []uint32 {
 	return encodeRegisterLists(UINT_TO_FIELD, []RegisterId{p.Target}, p.Source)

--- a/pkg/zkc/vm/internal/interpreter/encoding/field_cast.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/field_cast.go
@@ -38,7 +38,7 @@ import (
 // the (now u16) target and source registers two per word:
 //
 // +--------+--------+--------+--------+
-// |  nsrc  |  ntgt  |  n/a   | opcode |
+// |  nsrc  |  ntgt  |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       tgt1      |       tgt0      |
 // +-----------------+-----------------+

--- a/pkg/zkc/vm/internal/interpreter/encoding/readwrite.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/readwrite.go
@@ -127,7 +127,7 @@ func rwModeOf(kind uint8, write bool) RwMode {
 // per word:
 //
 // +--------+--------+--------+--------+
-// |  ndata |  naddr |  n/a   | opcode |
+// |  ndata |  naddr |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       ra0       |       id        |
 // +-----------------+-----------------+
@@ -152,7 +152,7 @@ func encodeReadWrite_sn(m RwMode, id uint16, addr []RegisterId, data []RegisterI
 	//
 	if IsWideRegisters(regs...) || id > math.MaxUint8 {
 		var (
-			codes = []uint32{ndata | naddr | opcode | WIDE}
+			codes = []uint32{ndata | naddr | (WIDE_RD_ROM_nm+uint32(m.Tag()))<<8 | WIDE}
 			// The identifier occupies the first packed slot, followed by the
 			// address and data registers.
 			shorts = make([]uint16, 0, 1+len(regs))

--- a/pkg/zkc/vm/internal/interpreter/encoding/readwrite.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/readwrite.go
@@ -13,6 +13,8 @@
 package encoding
 
 import (
+	"math"
+
 	"github.com/LFDT-Lineth/zkc/pkg/util"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/bytecode"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
@@ -60,7 +62,7 @@ func ReadWrite[W word.Word[W]](p *bytecode.ReadWrite[W], env Environment[W]) []u
 	var (
 		lab  = Label{p.Id, ProgramPoint{}}
 		sym  = env.SymbolAt(lab)
-		id   = util.Cast[uint8](sym.Offset)
+		id   = util.Cast[uint16](sym.Offset)
 		mode = rwModeOf(sym.Kind, p.Write)
 	)
 	//
@@ -119,28 +121,50 @@ func rwModeOf(kind uint8, write bool) RwMode {
 //
 //
 // Here, ra0...raN are u8 address registers, whilst rd0..rdN are u8 data
-// registers.  The wide form retains the header but packs the (now u16) address
-// and data registers two per word.
+// registers.  The wide form moves the (now u16) memory identifier into the
+// first packed slot (leaving bits 8-15 of the first word clear, as for all
+// wide forms), with the (now u16) address and data registers following two
+// per word:
+//
+// +--------+--------+--------+--------+
+// |  ndata |  naddr |  n/a   | opcode |
+// +--------+--------+--------+--------+
+// |       ra0       |       id        |
+// +-----------------+-----------------+
+// |       ra2       |       ra1       |
+// +-----------------+-----------------+
+// |   ... packed data registers ...   |
+// +-----------------------------------+
+//
+// The wide form is also selected when the registers are small but the memory
+// identifier exceeds a byte.
 // ============================================================================
 
 // encodeReadWrite_sn encodes a memory read/write instruction, packing its
 // address and data registers.  The opcode is determined by the read/write mode.
-func encodeReadWrite_sn(m RwMode, id uint8, addr []RegisterId, data []RegisterId) []uint32 {
+func encodeReadWrite_sn(m RwMode, id uint16, addr []RegisterId, data []RegisterId) []uint32 {
 	var (
 		opcode = RD_ROM_nm + uint32(m.Tag())
-		_id    = uint32(id) << 8
 		naddr  = uint32(util.Cast[uint8](uint(len(addr)))) << 16
 		ndata  = uint32(util.Cast[uint8](uint(len(data)))) << 24
 		regs   = append(RegsAsShorts(addr), RegsAsShorts(data)...)
 	)
 	//
-	if IsWideRegisters(regs...) {
-		var codes = []uint32{ndata | naddr | _id | opcode | WIDE}
+	if IsWideRegisters(regs...) || id > math.MaxUint8 {
+		var (
+			codes = []uint32{ndata | naddr | opcode | WIDE}
+			// The identifier occupies the first packed slot, followed by the
+			// address and data registers.
+			shorts = make([]uint16, 0, 1+len(regs))
+		)
 		//
-		return append(codes, PackShortsIntoCodes(regs)...)
+		shorts = append(shorts, id)
+		shorts = append(shorts, regs...)
+		//
+		return append(codes, PackShortsIntoCodes(shorts)...)
 	}
 	//
-	var codes = []uint32{ndata | naddr | _id | opcode}
+	var codes = []uint32{ndata | naddr | uint32(id)<<8 | opcode}
 	// construct register bytes
 	bytes := append(RegsAsBytes(addr), RegsAsBytes(data)...)
 	// pack bytes into bytecodes
@@ -151,13 +175,14 @@ func encodeReadWrite_sn(m RwMode, id uint8, addr []RegisterId, data []RegisterId
 func DecodeReadWrite_sn(pc uint32, codes []uint32) (id uint16, addr, data Operands, n uint32) {
 	naddr := uint((codes[pc] >> 16) & 0xff)
 	ndata := uint((codes[pc] >> 24) & 0xff)
-	id = uint16((codes[pc] >> 8) & 0xff)
 	//
 	if IsWideForm(pc, codes) {
-		addr = NewWideOperands(0, naddr, codes[pc+1:])
-		data = NewWideOperands(naddr, ndata, codes[pc+1:])
-		n = 1 + NumCodesPackedWide(naddr+ndata)
+		id = uint16(codes[pc+1] & 0xffff)
+		addr = NewWideOperands(1, naddr, codes[pc+1:])
+		data = NewWideOperands(1+naddr, ndata, codes[pc+1:])
+		n = 1 + NumCodesPackedWide(1+naddr+ndata)
 	} else {
+		id = uint16((codes[pc] >> 8) & 0xff)
 		addr = NewOperands(0, naddr, codes[pc+1:])
 		data = NewOperands(naddr, ndata, codes[pc+1:])
 		n = 1 + NumCodesPackedSmall(naddr+ndata)

--- a/pkg/zkc/vm/internal/interpreter/encoding/ret.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/ret.go
@@ -48,7 +48,7 @@ func Ret[W word.Word[W]](p *bytecode.Ret[W], env Environment[W]) []uint32 {
 // all wide forms) and the (now wider) offset into a subsequent word:
 //
 // +-----------------+--------+--------+
-// |   frame width   |  n/a   | opcode |
+// |   frame width   |  wop   |  WIDE  |
 // +-----------------+--------+--------+
 // | ............ offset ............. |
 // +-----------------------------------+
@@ -76,7 +76,7 @@ func encodeRet1(width uint16, roffset uint32) []uint32 {
 	//
 	if roffset > math.MaxUint8 {
 		return []uint32{
-			_width<<16 | RET | WIDE,
+			_width<<16 | WIDE_RET<<8 | WIDE,
 			roffset,
 		}
 	}

--- a/pkg/zkc/vm/internal/interpreter/encoding/ret.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/ret.go
@@ -44,27 +44,26 @@ func Ret[W word.Word[W]](p *bytecode.Ret[W], env Environment[W]) []uint32 {
 // +--------+-----------------+--------+
 //
 // Here, offset is the u8 offset of the return registers within the frame.  The
-// wide form keeps the frame width in place, moving the (now wider) offset into
-// a subsequent word:
+// wide form moves the frame width up a byte (leaving bits 8-15 clear, as for
+// all wide forms) and the (now wider) offset into a subsequent word:
 //
-// +--------+-----------------+--------+
-// |  n/a   |   frame width   | opcode |
-// +--------+-----------------+--------+
-// | ............ offset .............. |
-// +------------------------------------+
+// +-----------------+--------+--------+
+// |   frame width   |  n/a   | opcode |
+// +-----------------+--------+--------+
+// | ............ offset ............. |
+// +-----------------------------------+
 // ============================================================================
 
 // DecodeRet1 decodes the operands of a return instruction.
 func DecodeRet1(pc uint32, codes []uint32) (width uint16, roffset uint32, n uint32) {
-	// RET stores frame width in bits 8..23.
-	width = uint16((codes[pc] >> 8) & 0xffff)
-	//
 	if IsWideForm(pc, codes) {
+		width = uint16(codes[pc] >> 16)
 		roffset = codes[pc+1]
 		//
 		return width, roffset, 2
 	}
 	//
+	width = uint16((codes[pc] >> 8) & 0xffff)
 	roffset = codes[pc] >> 24
 	//
 	return width, roffset, 1
@@ -77,7 +76,7 @@ func encodeRet1(width uint16, roffset uint32) []uint32 {
 	//
 	if roffset > math.MaxUint8 {
 		return []uint32{
-			_width<<8 | RET | WIDE,
+			_width<<16 | RET | WIDE,
 			roffset,
 		}
 	}

--- a/pkg/zkc/vm/internal/interpreter/encoding/skip_if.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/skip_if.go
@@ -32,7 +32,7 @@ func SkipIf[W word.Word[W]](pc Address, b *bytecode.SkipIf[W], env Environment[W
 	)
 	//
 	if b.Right.IsConstant() {
-		return encodeSkipIfConstant(skip, b)
+		return encodeSkipIfConstant(skip, b, env)
 	}
 	//
 	var (
@@ -55,8 +55,8 @@ func SkipIf[W word.Word[W]](pc Address, b *bytecode.SkipIf[W], env Environment[W
 	)
 	//
 	switch {
-	case n == 1 && m == 1 && skip <= math.MaxUint8:
-		return encodeSkipIf_rr(util.Cast[uint8](skip), left.Base, right.Base, op)
+	case n == 1 && m == 1 && skip <= math.MaxUint16:
+		return encodeSkipIf_rr(util.Cast[uint16](skip), left.Base, right.Base, op)
 	case n == m:
 		return encodeSkipIf_rv(skip, left, right, op)
 	default:
@@ -71,7 +71,7 @@ func SkipIf[W word.Word[W]](pc Address, b *bytecode.SkipIf[W], env Environment[W
 // (x > c ⇔ x >= c+1, x <= c ⇔ x < c+1); when c+1 overflows, the condition is
 // statically decided and encoded as a comparison against zero which is
 // trivially false (x < 0) or trivially true (x >= 0).
-func encodeSkipIfConstant[W word.Word[W]](skip uint32, b *bytecode.SkipIf[W]) []uint32 {
+func encodeSkipIfConstant[W word.Word[W]](skip uint32, b *bytecode.SkipIf[W], env Environment[W]) []uint32 {
 	var (
 		nv = uint(b.Left.Len)
 		op = b.Op
@@ -107,14 +107,19 @@ func encodeSkipIfConstant[W word.Word[W]](skip uint32, b *bytecode.SkipIf[W]) []
 		}
 	}
 	//
-	// The compact single-constant form carries its skip as a u8 and its
-	// register as a u8 in the initial word; anything larger falls back to the
-	// general constant-vector form with a single element.
+	// The compact single-constant form carries its skip, register and constant
+	// pool identifier as u8 fields in a single word; anything larger falls
+	// back to the general constant-vector form with a single element.  NOTE:
+	// the pool identifier is stable across encoding passes (ConstantIndex
+	// interns), so this choice cannot oscillate whilst the layout reaches a
+	// fixpoint.
 	if nv == 1 && skip <= math.MaxUint8 && !IsWideRegisters(b.Left.Base) {
-		return encodeSkipIf_rc(util.Cast[uint8](skip), b.Left.Base, constants[0], op)
+		if cid := env.ConstantIndex(constants[0]); cid <= math.MaxUint8 {
+			return encodeSkipIf_rc(util.Cast[uint8](skip), b.Left.Base, uint8(cid), op)
+		}
 	}
 	//
-	return encodeSkipIf_rcv(skip, b.Left, constants, op)
+	return encodeSkipIf_rcv(skip, b.Left, constants, op, env)
 }
 
 // incrementConstants increments a constant vector (most significant element
@@ -187,23 +192,28 @@ func condFromOffset(offset uint32) Cond {
 // Here, skip is a u8 identifying the number of instructions to skip, where the
 // following instruction is considered to be at offset 0.  Likewise, rs0 and rs1
 // are u8 source registers, whilst op identifies the operation.  The wide form
-// keeps skip in place, moving the (now u16) registers into a subsequent word:
+// extends the skip to a u16 in the upper half of the first word, moving the
+// (now u16) registers into a subsequent word:
 //
 // +--------+--------+--------+--------+
-// |  skip  |       n/a       | opcode |
+// |      skip       |  n/a   | opcode |
 // +--------+--------+--------+--------+
 // |       rs0       |       rs1       |
 // +-----------------+-----------------+
+//
+// The wide form is also selected when the registers are small but the skip
+// exceeds a byte; a skip exceeding u16 falls back to the register-vector form
+// (SXX_rv), which carries a u32 skip.
 // ============================================================================
 
 // encodeSkipIf_rr encodes a register-register conditional skip instruction,
 // where op identifies the comparison.
-func encodeSkipIf_rr(skip uint8, rs0, rs1 RegisterId, op Cond) []uint32 {
+func encodeSkipIf_rr(skip uint16, rs0, rs1 RegisterId, op Cond) []uint32 {
 	// Forward branches are preferred as SKIP_IF instructions, whose offset is
 	// unsigned and hence offers a greater forward range.
-	if IsWideRegisters(rs0, rs1) {
+	if IsWideRegisters(rs0, rs1) || skip > math.MaxUint8 {
 		return []uint32{
-			uint32(skip)<<24 | (SEQ_rr + condOffset(op)) | WIDE,
+			uint32(skip)<<16 | (SEQ_rr + condOffset(op)) | WIDE,
 			uint32(rs1) | uint32(rs0)<<16,
 		}
 	}
@@ -224,13 +234,14 @@ func encodeSkipIf_rr(skip uint8, rs0, rs1 RegisterId, op Cond) []uint32 {
 // DecodeSkipIf_rr decodes the operands of a register-register conditional skip.
 func DecodeSkipIf_rr(pc uint32, codes []uint32) (skip uint32, rs0, rs1 RegisterId, op Cond, n uint32) {
 	op = condFromOffset((codes[pc] & OPCODE_MASK) - SEQ_rr)
-	skip = codes[pc] >> 24
 	//
 	if IsWideForm(pc, codes) {
+		skip = codes[pc] >> 16
 		rs1 = RegisterId(codes[pc+1] & 0xffff)
 		rs0 = RegisterId(codes[pc+1] >> 16)
 		n = 2
 	} else {
+		skip = codes[pc] >> 24
 		rs1 = RegisterId((codes[pc] >> 8) & 0xff)
 		rs0 = RegisterId((codes[pc] >> 16) & 0xff)
 		n = 1
@@ -287,209 +298,6 @@ func encodeSkipIf_rv(skip uint32, rs0, rs1 RegisterVector, op Cond) []uint32 {
 	}
 }
 
-// ============================================================================
-// seq/sne/slt,sge (skip conditional) instruction with a single register and a
-// single constant operand.  Format is:
-//
-//	31                                0
-//
-// +--------+--------+--------+--------+
-// |  skip  |  rs0   |   nc   | opcode |
-// +--------+--------+--------+--------+
-// | ...... constant limb (ls) ....... |
-// +--------+--------+--------+--------+
-// |                ...                |
-// +-----------------------------------+
-//
-// Here, skip is a u8 identifying the number of instructions to skip (where the
-// following instruction is considered to be at offset 0), rs0 is the u8 source
-// register and the constant follows inline as nc 32-bit limbs (least
-// significant first).  There is no wide form: a wide (u16) register, or a skip
-// exceeding u8, falls back to the general constant-vector form (SXX_rcv) with
-// a single element.
-// ============================================================================
-
-// encodeSkipIf_rc encodes a register-constant conditional skip instruction,
-// where op identifies the (normalised) comparison.
-func encodeSkipIf_rc[W word.Word[W]](skip uint8, rs0 RegisterId, constant W, op Cond) []uint32 {
-	var (
-		// NOTE: big-endian byte ordering
-		bytes  = constant.BigInt().Bytes()
-		nlimbs = max(1, (len(bytes)+3)/4)
-		//
-		codes = make([]uint32, nlimbs+1)
-	)
-	//
-	if nlimbs > 0xff {
-		panic("constant exceeds register-constant skip form")
-	}
-
-	codes[0] = uint32(skip)<<24 | uint32(rs0)<<16 | uint32(nlimbs)<<8 | (SEQ_rc + condOffset(op))
-	// Pack bytes into limbs, least significant limb first.
-	for i, b := range bytes {
-		var k = uint(len(bytes) - 1 - i)
-		//
-		codes[1+(k/4)] |= uint32(b) << (8 * (k % 4))
-	}
-	//
-	return codes
-}
-
-// DecodeSkipIf_rc decodes the operands of a register-constant conditional
-// skip.
-func DecodeSkipIf_rc[W word.Word[W]](pc uint32, codes []uint32) (skip uint32, rs0 RegisterId, constant W,
-	op Cond, n uint32) {
-	var nlimbs = (codes[pc] >> 8) & 0xff
-	//
-	op = condFromOffset((codes[pc] & OPCODE_MASK) - SEQ_rc)
-	skip = codes[pc] >> 24
-	rs0 = RegisterId((codes[pc] >> 16) & 0xff)
-	// Unpack limbs, most significant limb first.  The constant was encoded
-	// from a W, so it fits: the shift never spills into hi and, since the low
-	// 32 bits are zero after shifting, the add cannot carry.
-	for i := nlimbs; i > 0; i-- {
-		_, constant = constant.Shl64(32)
-		constant, _ = constant.Add64(uint64(codes[pc+i]))
-	}
-	//
-	return skip, rs0, constant, op, nlimbs + 1
-}
-
-// ============================================================================
-// seq/sne/slt,sge (skip conditional) instruction with a register vector and a
-// constant vector operand.  Format is:
-//
-//	31                                0
-//
-// +--------+--------+--------+--------+
-// |   nv   |  rs0   |   nc   | opcode |
-// +--------+--------+--------+--------+
-// | ............. skip .............. |
-// +--------+--------+--------+--------+
-// | .... element 0, limb 0 (ls) ..... |
-// +--------+--------+--------+--------+
-// |                ...                |
-// +-----------------------------------+
-//
-// Here, rs0 is the u8 base of the register vector, nv its length and skip an
-// unsigned u32 relative offset (where the following instruction is considered
-// to be at offset 0).  The constant vector follows inline as nv elements
-// (most significant element first, mirroring the register vector layout), each
-// occupying exactly nc 32-bit limbs (least significant limb first).  The wide
-// form keeps nv, nc and skip in place, moving the (now u16) base register into
-// a word of its own, ahead of the constant limbs:
-//
-// +--------+--------+--------+--------+
-// |   nv   |  n/a   |   nc   | opcode |
-// +--------+--------+--------+--------+
-// | ............. skip .............. |
-// +--------+--------+--------+--------+
-// |       n/a       |       rs0       |
-// +-----------------+-----------------+
-// | .... element 0, limb 0 (ls) ..... |
-// +--------+--------+--------+--------+
-// ============================================================================
-
-// encodeSkipIf_rcv encodes a register vector versus constant vector
-// conditional skip instruction, where op identifies the (normalised)
-// comparison.  The constants must carry exactly one element per register (see
-// encodeSkipIfConstant, which zero-extends them).
-func encodeSkipIf_rcv[W word.Word[W]](skip uint32, rs0 RegisterVector, constants []W, op Cond) []uint32 {
-	var (
-		nv = uint(util.Cast[uint8](rs0.Len))
-		// Number of limbs per element, fixed across the vector.
-		nc    uint
-		wide  = IsWideRegisters(rs0.Base)
-		first uint
-		codes []uint32
-	)
-	// check core invariant
-	if uint(len(constants)) != nv {
-		panic(fmt.Sprintf("mismatched length for constant vector (%d vs %d)", len(constants), nv))
-	}
-	//
-	for _, c := range constants {
-		nc = max(nc, (c.BitLen()+31)/32)
-	}
-	//
-	nc = max(nc, 1)
-	//
-	if nc > 0xff {
-		panic("constant exceeds register-constant skip form")
-	}
-	//
-	if wide {
-		codes = make([]uint32, 3+(nv*nc))
-		codes[0] = uint32(nv)<<24 | uint32(nc)<<8 | (SEQ_rcv + condOffset(op)) | WIDE
-		codes[1] = skip
-		codes[2] = uint32(rs0.Base)
-		first = 3
-	} else {
-		codes = make([]uint32, 2+(nv*nc))
-		codes[0] = uint32(nv)<<24 | uint32(rs0.Base)<<16 | uint32(nc)<<8 | (SEQ_rcv + condOffset(op))
-		codes[1] = skip
-		first = 2
-	}
-	// Pack each element's bytes into its limbs, least significant limb first.
-	for e, c := range constants {
-		var (
-			// NOTE: big-endian byte ordering
-			bytes = c.BigInt().Bytes()
-			base  = first + (uint(e) * nc)
-		)
-		//
-		for i, b := range bytes {
-			var k = uint(len(bytes) - 1 - i)
-			//
-			codes[base+(k/4)] |= uint32(b) << (8 * (k % 4))
-		}
-	}
-	//
-	return codes
-}
-
-// DecodeSkipIf_rcv decodes the operands of a register vector versus constant
-// vector conditional skip.
-func DecodeSkipIf_rcv[W word.Word[W]](pc uint32, codes []uint32) (skip uint32, rs0 RegisterVector,
-	constants []W, op Cond, n uint32) {
-	var (
-		nv    = codes[pc] >> 24
-		nc    = (codes[pc] >> 8) & 0xff
-		base  RegisterId
-		first uint32
-	)
-	//
-	op = condFromOffset((codes[pc] & OPCODE_MASK) - SEQ_rcv)
-	skip = codes[pc+1]
-	//
-	if IsWideForm(pc, codes) {
-		base = RegisterId(codes[pc+2] & 0xffff)
-		first = pc + 3
-	} else {
-		base = RegisterId((codes[pc] >> 16) & 0xff)
-		first = pc + 2
-	}
-	//
-	constants = make([]W, nv)
-	// Unpack each element's limbs, most significant limb first.  Each element
-	// was encoded from a W, so it fits: the shift never spills into hi and,
-	// since the low 32 bits are zero after shifting, the add cannot carry.
-	for e := uint32(0); e < nv; e++ {
-		var c W
-		//
-		for i := nc; i > 0; i-- {
-			_, c = c.Shl64(32)
-			c, _ = c.Add64(uint64(codes[first+(e*nc)+i-1]))
-		}
-		//
-		constants[e] = c
-	}
-	//
-	rs0 = RegisterVector{Base: base, Len: util.Cast[uint16](uint(nv))}
-	//
-	return skip, rs0, constants, op, (first - pc) + (nv * nc)
-}
-
 // DecodeSkipIf_rv decodes the operands of a register-vector conditional branch.
 func DecodeSkipIf_rv(pc uint32, codes []uint32) (skip uint32, rs0, rs1 RegisterVector, op Cond, n uint32) {
 	var (
@@ -514,4 +322,159 @@ func DecodeSkipIf_rv(pc uint32, codes []uint32) (skip uint32, rs0, rs1 RegisterV
 	rs1 = RegisterVector{Base: rs1b, Len: nv}
 	//
 	return skip, rs0, rs1, op, n
+}
+
+// ============================================================================
+// seq/sne/slt,sge (skip conditional) instruction with a single register and a
+// single constant operand.  Format is:
+//
+//	31                                0
+//
+// +--------+--------+--------+--------+
+// |  skip  |  rs0   |  cid   | opcode |
+// +--------+--------+--------+--------+
+//
+// Here, skip is a u8 identifying the number of instructions to skip (where the
+// following instruction is considered to be at offset 0), rs0 is the u8 source
+// register and cid is a u8 constant pool identifier for the constant operand.
+// There is no wide form: a wide (u16) register, a skip exceeding u8, or a pool
+// identifier exceeding u8 falls back to the general constant-vector form
+// (SXX_rcv) with a single element.
+// ============================================================================
+
+// encodeSkipIf_rc encodes a register-constant conditional skip instruction,
+// where op identifies the (normalised) comparison.
+func encodeSkipIf_rc(skip uint8, rs0 RegisterId, cid uint8, op Cond) []uint32 {
+	return []uint32{
+		uint32(skip)<<24 | uint32(rs0)<<16 | uint32(cid)<<8 | (SEQ_rc + condOffset(op)),
+	}
+}
+
+// DecodeSkipIf_rc decodes the operands of a register-constant conditional
+// skip.
+func DecodeSkipIf_rc[W word.Word[W]](pc uint32, codes []uint32, pool []W) (skip uint32, rs0 RegisterId,
+	constant W, op Cond, n uint32) {
+	//
+	op = condFromOffset((codes[pc] & OPCODE_MASK) - SEQ_rc)
+	skip = codes[pc] >> 24
+	rs0 = RegisterId((codes[pc] >> 16) & 0xff)
+	constant = pool[(codes[pc]>>8)&0xff]
+	//
+	return skip, rs0, constant, op, 1
+}
+
+// ============================================================================
+// seq/sne/slt,sge (skip conditional) instruction with a register vector and a
+// constant vector operand.  Format of the compact form is:
+//
+//	31                                0
+//
+// +--------+--------+--------+--------+
+// |   nv   |  rs0   |  n/a   | opcode |
+// +--------+--------+--------+--------+
+// |      skip       |  cid   |   cn   |
+// +-----------------+--------+--------+
+//
+// Here, rs0 is the u8 base of the register vector, nv its length and skip an
+// unsigned u16 relative offset (where the following instruction is considered
+// to be at offset 0).  The constant vector is described by cid and cn: a u8
+// base constant pool identifier and u8 length, such that element i of the
+// vector (most significant first, mirroring the register vector layout)
+// resides at pool index cid+i.  The general (WIDE) form serves as the
+// fallback whenever the compact fields do not fit — a wide (u16) base
+// register, or a base pool identifier exceeding u8.  It keeps the u16 skip in
+// the first word, carrying the register vector (u16 base and length) in the
+// second word and the constant vector (u16 base pool identifier and length)
+// in the third:
+//
+// +--------+--------+--------+--------+
+// |      skip       |  n/a   | opcode |
+// +--------+--------+--------+--------+
+// |       nv        |       rs0       |
+// +-----------------+-----------------+
+// |       cn        |       cid       |
+// +-----------------+-----------------+
+//
+// There is no encoding for a skip exceeding u16 (as for SKIP, whose offset is
+// bounded by its instruction format, encoding panics instead).
+// ============================================================================
+
+// encodeSkipIf_rcv encodes a register vector versus constant vector
+// conditional skip instruction, where op identifies the (normalised)
+// comparison.  The constants must carry exactly one element per register (see
+// encodeSkipIfConstant, which zero-extends them).
+func encodeSkipIf_rcv[W word.Word[W]](skip uint32, rs0 RegisterVector, constants []W, op Cond,
+	env Environment[W]) []uint32 {
+	//
+	var (
+		nv     = uint(util.Cast[uint8](rs0.Len))
+		opcode = SEQ_rcv + condOffset(op)
+	)
+	// check core invariant
+	if uint(len(constants)) != nv {
+		panic(fmt.Sprintf("mismatched length for constant vector (%d vs %d)", len(constants), nv))
+	}
+	// Neither form can encode a skip exceeding u16.
+	if skip > math.MaxUint16 {
+		panic("skip exceeds conditional skip form")
+	}
+	// The compact form carries a u8 base pool identifier and u8 length
+	// describing the constant vector as a consecutive run of pool entries;
+	// anything larger falls back to the general (WIDE) form.  NOTE: pool
+	// identifiers are stable across encoding passes (interning), so this
+	// choice cannot oscillate whilst the layout reaches a fixpoint.
+	if !IsWideRegisters(rs0.Base) {
+		if cid := env.ConstantVectorIndex(constants); cid <= math.MaxUint8 {
+			return []uint32{
+				uint32(nv)<<24 | uint32(rs0.Base)<<16 | opcode,
+				skip<<16 | uint32(cid)<<8 | uint32(nv),
+			}
+		}
+	}
+	// General form
+	var cid = env.ConstantVectorIndex(constants)
+	//
+	return []uint32{
+		skip<<16 | opcode | WIDE,
+		uint32(nv)<<16 | uint32(rs0.Base),
+		uint32(nv)<<16 | uint32(cid),
+	}
+}
+
+// DecodeSkipIf_rcv decodes the operands of a register vector versus constant
+// vector conditional skip.
+func DecodeSkipIf_rcv[W word.Word[W]](pc uint32, codes []uint32, pool []W) (skip uint32, rs0 RegisterVector,
+	constants []W, op Cond, n uint32) {
+	//
+	op = condFromOffset((codes[pc] & OPCODE_MASK) - SEQ_rcv)
+	// NOTE: in both forms, the constant vector is a consecutive run of pool
+	// entries.
+	if IsWideForm(pc, codes) {
+		var (
+			cid = codes[pc+2] & 0xffff
+			cn  = codes[pc+2] >> 16
+		)
+		//
+		skip = codes[pc] >> 16
+		constants = pool[cid : cid+cn]
+		rs0 = RegisterVector{
+			Base: RegisterId(codes[pc+1] & 0xffff),
+			Len:  RegisterId(codes[pc+1] >> 16),
+		}
+		//
+		return skip, rs0, constants, op, 3
+	}
+	//
+	var (
+		nv    = codes[pc] >> 24
+		word1 = codes[pc+1]
+		cid   = (word1 >> 8) & 0xff
+		cn    = word1 & 0xff
+	)
+	//
+	skip = word1 >> 16
+	constants = pool[cid : cid+cn]
+	rs0 = RegisterVector{Base: RegisterId((codes[pc] >> 16) & 0xff), Len: util.Cast[uint16](uint(nv))}
+	//
+	return skip, rs0, constants, op, 2
 }

--- a/pkg/zkc/vm/internal/interpreter/encoding/skip_if.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/skip_if.go
@@ -196,7 +196,7 @@ func condFromOffset(offset uint32) Cond {
 // (now u16) registers into a subsequent word:
 //
 // +--------+--------+--------+--------+
-// |      skip       |  n/a   | opcode |
+// |      skip       |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       rs0       |       rs1       |
 // +-----------------+-----------------+
@@ -213,7 +213,7 @@ func encodeSkipIf_rr(skip uint16, rs0, rs1 RegisterId, op Cond) []uint32 {
 	// unsigned and hence offers a greater forward range.
 	if IsWideRegisters(rs0, rs1) || skip > math.MaxUint8 {
 		return []uint32{
-			uint32(skip)<<16 | (SEQ_rr + condOffset(op)) | WIDE,
+			uint32(skip)<<16 | (WIDE_SEQ_rr+condOffset(op))<<8 | WIDE,
 			uint32(rs1) | uint32(rs0)<<16,
 		}
 	}
@@ -233,14 +233,14 @@ func encodeSkipIf_rr(skip uint16, rs0, rs1 RegisterId, op Cond) []uint32 {
 
 // DecodeSkipIf_rr decodes the operands of a register-register conditional skip.
 func DecodeSkipIf_rr(pc uint32, codes []uint32) (skip uint32, rs0, rs1 RegisterId, op Cond, n uint32) {
-	op = condFromOffset((codes[pc] & OPCODE_MASK) - SEQ_rr)
-	//
 	if IsWideForm(pc, codes) {
+		op = condFromOffset(((codes[pc] >> 8) & 0xff) - WIDE_SEQ_rr)
 		skip = codes[pc] >> 16
 		rs1 = RegisterId(codes[pc+1] & 0xffff)
 		rs0 = RegisterId(codes[pc+1] >> 16)
 		n = 2
 	} else {
+		op = condFromOffset((codes[pc] & OPCODE_MASK) - SEQ_rr)
 		skip = codes[pc] >> 24
 		rs1 = RegisterId((codes[pc] >> 8) & 0xff)
 		rs0 = RegisterId((codes[pc] >> 16) & 0xff)
@@ -269,7 +269,7 @@ func DecodeSkipIf_rr(pc uint32, codes []uint32) (skip uint32, rs0, rs1 RegisterI
 // third word:
 //
 // +--------+--------+--------+--------+
-// |   nv   |       n/a       | opcode |
+// |   nv   |  n/a   |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // | ............ target ............. |
 // +--------+--------+--------+--------+
@@ -286,7 +286,7 @@ func encodeSkipIf_rv(skip uint32, rs0, rs1 RegisterVector, op Cond) []uint32 {
 	//
 	if IsWideRegisters(rs0.Base, rs1.Base) {
 		return []uint32{
-			nv | (SEQ_rv + condOffset(op)) | WIDE,
+			nv | (WIDE_SEQ_rv+condOffset(op))<<8 | WIDE,
 			skip,
 			uint32(rs1.Base) | uint32(rs0.Base)<<16,
 		}
@@ -305,14 +305,15 @@ func DecodeSkipIf_rv(pc uint32, codes []uint32) (skip uint32, rs0, rs1 RegisterV
 		nv         = RegisterId((codes[pc] >> 24) & 0xff)
 	)
 	//
-	op = condFromOffset((codes[pc] & OPCODE_MASK) - SEQ_rv)
 	skip = codes[pc+1]
 	//
 	if IsWideForm(pc, codes) {
+		op = condFromOffset(((codes[pc] >> 8) & 0xff) - WIDE_SEQ_rv)
 		rs1b = RegisterId(codes[pc+2] & 0xffff)
 		rs0b = RegisterId(codes[pc+2] >> 16)
 		n = 3
 	} else {
+		op = condFromOffset((codes[pc] & OPCODE_MASK) - SEQ_rv)
 		rs1b = RegisterId((codes[pc] >> 8) & 0xff)
 		rs0b = RegisterId((codes[pc] >> 16) & 0xff)
 		n = 2
@@ -380,7 +381,7 @@ func DecodeSkipIf_rc[W word.Word[W]](pc uint32, codes []uint32, pool []W) (skip 
 // to be at offset 0).  The constant vector is described by cid and cn: a u8
 // base constant pool identifier and u8 length, such that element i of the
 // vector (most significant first, mirroring the register vector layout)
-// resides at pool index cid+i.  The general (WIDE) form serves as the
+// resides at pool index cid+i.  The general (wide) form serves as the
 // fallback whenever the compact fields do not fit — a wide (u16) base
 // register, or a base pool identifier exceeding u8.  It keeps the u16 skip in
 // the first word, carrying the register vector (u16 base and length) in the
@@ -388,7 +389,7 @@ func DecodeSkipIf_rc[W word.Word[W]](pc uint32, codes []uint32, pool []W) (skip 
 // in the third:
 //
 // +--------+--------+--------+--------+
-// |      skip       |  n/a   | opcode |
+// |      skip       |  wop   |  WIDE  |
 // +--------+--------+--------+--------+
 // |       nv        |       rs0       |
 // +-----------------+-----------------+
@@ -420,7 +421,7 @@ func encodeSkipIf_rcv[W word.Word[W]](skip uint32, rs0 RegisterVector, constants
 	}
 	// The compact form carries a u8 base pool identifier and u8 length
 	// describing the constant vector as a consecutive run of pool entries;
-	// anything larger falls back to the general (WIDE) form.  NOTE: pool
+	// anything larger falls back to the general (wide) form.  NOTE: pool
 	// identifiers are stable across encoding passes (interning), so this
 	// choice cannot oscillate whilst the layout reaches a fixpoint.
 	if !IsWideRegisters(rs0.Base) {
@@ -435,7 +436,7 @@ func encodeSkipIf_rcv[W word.Word[W]](skip uint32, rs0 RegisterVector, constants
 	var cid = env.ConstantVectorIndex(constants)
 	//
 	return []uint32{
-		skip<<16 | opcode | WIDE,
+		skip<<16 | (WIDE_SEQ_rcv+condOffset(op))<<8 | WIDE,
 		uint32(nv)<<16 | uint32(rs0.Base),
 		uint32(nv)<<16 | uint32(cid),
 	}
@@ -446,7 +447,6 @@ func encodeSkipIf_rcv[W word.Word[W]](skip uint32, rs0 RegisterVector, constants
 func DecodeSkipIf_rcv[W word.Word[W]](pc uint32, codes []uint32, pool []W) (skip uint32, rs0 RegisterVector,
 	constants []W, op Cond, n uint32) {
 	//
-	op = condFromOffset((codes[pc] & OPCODE_MASK) - SEQ_rcv)
 	// NOTE: in both forms, the constant vector is a consecutive run of pool
 	// entries.
 	if IsWideForm(pc, codes) {
@@ -455,6 +455,7 @@ func DecodeSkipIf_rcv[W word.Word[W]](pc uint32, codes []uint32, pool []W) (skip
 			cn  = codes[pc+2] >> 16
 		)
 		//
+		op = condFromOffset(((codes[pc] >> 8) & 0xff) - WIDE_SEQ_rcv)
 		skip = codes[pc] >> 16
 		constants = pool[cid : cid+cn]
 		rs0 = RegisterVector{
@@ -472,6 +473,7 @@ func DecodeSkipIf_rcv[W word.Word[W]](pc uint32, codes []uint32, pool []W) (skip
 		cn    = word1 & 0xff
 	)
 	//
+	op = condFromOffset((codes[pc] & OPCODE_MASK) - SEQ_rcv)
 	skip = word1 >> 16
 	constants = pool[cid : cid+cn]
 	rs0 = RegisterVector{Base: RegisterId((codes[pc] >> 16) & 0xff), Len: util.Cast[uint16](uint(nv))}

--- a/pkg/zkc/vm/internal/interpreter/encoding/switch.go
+++ b/pkg/zkc/vm/internal/interpreter/encoding/switch.go
@@ -27,54 +27,47 @@ import (
 // +--------+--------+--------+--------+
 // |  count |     source      | opcode |
 // +--------+--------+--------+--------+
-// |      case 0: value (low 32)       |
-// +-----------------------------------+
-// |      case 0: value (high 32)      |
-// +-----------------------------------+
-// |          case 0: target           |
-// +-----------------------------------+
+// |  case 0: skip   |  case 0: cid    |
+// +-----------------+-----------------+
 // |                ...                |
-// +-----------------------------------+
-// |   case count-1: value (low 32)    |
-// +-----------------------------------+
-// |   case count-1: value (high 32)   |
-// +-----------------------------------+
-// |       case count-1: target        |
-// +-----------------------------------+
+// +-----------------+-----------------+
+// |  count-1: skip  |  count-1: cid   |
+// +-----------------+-----------------+
 //
 // Here, source identifies the register being switched upon and count gives the
-// number of (value, target) cases which follow.  Each case is encoded as a
-// 64-bit value (least-significant limb first) followed by an absolute u32 target
-// address.  Control transfers to the target of the first case whose value
-// matches the source register.
+// number of cases which follow, one word each.  Each case is encoded as a u16
+// constant pool identifier for its value together with an unsigned u16
+// relative skip offset (where the following instruction is considered to be
+// at offset 0, as for the other skip forms).  Control skips forward to the
+// target of the first case whose value matches the source register.  There is
+// no encoding for a skip exceeding u16 (encoding panics instead).
 // ============================================================================
 
 // Switch encodes a multiway-skip (switch) bytecode, which dispatches on a source
-// register against a table of (value, target) pairs.
-func Switch[W word.Word[W]](p *bytecode.Switch[W], env Environment[W]) []uint32 {
+// register against a table of (value, skip) pairs.
+func Switch[W word.Word[W]](pc Address, p *bytecode.Switch[W], env Environment[W]) []uint32 {
 	// count occupies a single byte (bits 24..31) of word 0.
 	if len(p.Cases) > math.MaxUint8 {
 		panic("too many cases in multiway skip")
 	}
 	// word 0: count | source | opcode
 	var codes = []uint32{uint32(len(p.Cases))<<24 | uint32(p.Source)<<8 | SKIP_M}
-	// Append one (value_lo, value_hi, target) triple per case.
+	// Append one (skip, cid) word per case.
 	for _, c := range p.Cases {
 		var (
 			// Resolve this case's target program point, ...
 			target = env.Point().Skip(uint(c.Skip))
-			// ... then its absolute offset in the encoded sequence (SKIP_M
-			// targets are absolute, unlike the relative SKIP/JMP forms).
-			offset = env.OffsetFor(env.enclosing, target)
+			// ... then its relative offset from the following instruction.
+			skip = env.OffsetFor(env.enclosing, target) - (pc + 1)
+			//
+			cid = env.ConstantIndex(c.Value)
 		)
-		// sanity check (for now)
-		if c.Value.Cmp64(^uint64(0)) > 0 {
-			panic("wide switch constants not supported")
-		}
-		// Convert into uint64
-		value := c.Value.Uint64()
 		//
-		codes = append(codes, uint32(value), uint32(value>>32), offset)
+		if skip > math.MaxUint16 {
+			panic("skip exceeds multiway skip form")
+		}
+		//
+		codes = append(codes, skip<<16|uint32(cid))
 	}
 	//
 	return codes
@@ -90,14 +83,14 @@ func DecodeSkipTable[W word.Word[W]](pc uint32, codes []uint32) (Bytecode[W], ui
 	// )
 	// //
 	// for i := range count {
-	// 	var base = pc + 1 + (i * 3)
+	// 	var word = codes[pc+1+i]
 	// 	//
 	// 	cases[i] = bytecode.SwitchCase{
-	// 		Value:  uint64(codes[base]) | (uint64(codes[base+1]) << 32),
-	// 		Target: codes[base+2],
+	// 		Value: pool[word&0xffff],
+	// 		Skip:  word >> 16,
 	// 	}
 	// }
 	// //
-	// return &bytecode.Switch{Source: source, Cases: cases}, 1 + (3 * count)
+	// return &bytecode.Switch{Source: source, Cases: cases}, 1 + count
 	panic("not efficient")
 }

--- a/pkg/zkc/vm/internal/interpreter/interpreter.go
+++ b/pkg/zkc/vm/internal/interpreter/interpreter.go
@@ -581,9 +581,17 @@ func (p *Interpreter[W]) Execute(steps uint) (uint, error) {
 			opcode     = bytecodes[p.pc] & encoding.OPCODE_MASK
 			breakpoint = bytecodes[p.pc]&encoding.BREAKPOINT != 0
 		)
-		// Check for breakpoint.
+		// Check for breakpoint.  NOTE: for wide instructions, the wide opcode
+		// (second byte) is passed through alongside the WIDE escape, allowing
+		// observers to identify the instruction (e.g. WIDE|WIDE_RET<<8).
 		if breakpoint {
-			p.breakpoint(opcode)
+			var cbop = opcode
+			//
+			if opcode == encoding.WIDE {
+				cbop |= bytecodes[p.pc] & 0xff00
+			}
+			//
+			p.breakpoint(cbop)
 		}
 		// increase step counter
 		nsteps++
@@ -591,6 +599,17 @@ func (p *Interpreter[W]) Execute(steps uint) (uint, error) {
 		switch opcode & encoding.OPCODE_MASK {
 		case encoding.FAIL:
 			return nsteps, p.executeFail(p.pc, bytecodes, frame)
+		case encoding.WIDE:
+			var halt bool
+			//
+			p.pc, halt, err = p.executeWide(p.pc, bytecodes, pool, frame)
+			//
+			if halt {
+				return nsteps, err
+			}
+			// refresh the register window, since wide instructions include
+			// those (ENTER/LEAVE/RET) which change the enclosing frame.
+			frame = p.dataStack.SliceEnd(uint(p.fp))
 		case encoding.CHECKCAST:
 			p.pc, err = p.executeCheckCast(p.pc, bytecodes, frame)
 		case encoding.DEBUG:
@@ -728,6 +747,135 @@ func (p *Interpreter[W]) Execute(steps uint) (uint, error) {
 	}
 	//
 	return nsteps, err
+}
+
+// executeWide dispatches an instruction encoded via the WIDE escape opcode,
+// switching on the wide opcode held in the second byte of its first word.  It
+// returns the next program counter, together with a halt flag signalling that
+// execution has terminated (i.e. an explicit failure, or a return from the
+// outermost frame) and any error.
+//
+//nolint:funlen
+func (p *Interpreter[W]) executeWide(pc uint32, codes []uint32, pool []W, stack []W) (uint32, bool, error) {
+	var (
+		wopcode = (codes[pc] >> 8) & 0xff
+		err     error
+	)
+	//
+	switch wopcode {
+	case encoding.WIDE_FAIL:
+		return pc, true, p.executeFail(pc, codes, stack)
+	case encoding.WIDE_CHECKCAST:
+		pc, err = executeCheckCast(pc, codes, stack)
+	case encoding.WIDE_DEBUG:
+		pc = p.executeDebug(pc, codes, stack)
+	case encoding.WIDE_LDC_w:
+		pc = executeLdc_w(pc, codes, pool, stack)
+	case encoding.WIDE_MOVE:
+		pc = executeMove_1s1(pc, codes, stack)
+	case encoding.WIDE_ENTER_n:
+		err = p.executeEnter_n(pc, codes, stack)
+		pc = p.pc
+	case encoding.WIDE_LEAVE_n:
+		pc = p.executeLeave_n(pc, codes, stack)
+	case encoding.WIDE_RET:
+		// check for termination
+		if p.callStack.Size() == 0 {
+			return pc, true, nil
+		}
+		// normal return
+		pc, err = p.executeReturn(pc, codes)
+	case encoding.WIDE_SEQ_rr:
+		pc = executeSkipIf_rr[W, util.Equal[W]](pc, codes, stack)
+	case encoding.WIDE_SNE_rr:
+		pc = executeSkipIf_rr[W, util.NotEqual[W]](pc, codes, stack)
+	case encoding.WIDE_SLT_rr:
+		pc = executeSkipIf_rr[W, util.LessThan[W]](pc, codes, stack)
+	case encoding.WIDE_SGE_rr:
+		pc = executeSkipIf_rr[W, util.GreaterThanOrEqual[W]](pc, codes, stack)
+	case encoding.WIDE_SEQ_rv:
+		pc = executeSkipIf_rv[W, util.Equal[W]](pc, codes, stack)
+	case encoding.WIDE_SNE_rv:
+		pc = executeSkipIf_rv[W, util.NotEqual[W]](pc, codes, stack)
+	case encoding.WIDE_SLT_rv:
+		pc = executeSkipIf_rv[W, util.LessThan[W]](pc, codes, stack)
+	case encoding.WIDE_SGE_rv:
+		pc = executeSkipIf_rv[W, util.GreaterThanOrEqual[W]](pc, codes, stack)
+	case encoding.WIDE_SEQ_rcv:
+		pc = executeSkipIf_rcv[W, util.Equal[W]](pc, codes, pool, stack)
+	case encoding.WIDE_SNE_rcv:
+		pc = executeSkipIf_rcv[W, util.NotEqual[W]](pc, codes, pool, stack)
+	case encoding.WIDE_SLT_rcv:
+		pc = executeSkipIf_rcv[W, util.LessThan[W]](pc, codes, pool, stack)
+	case encoding.WIDE_SGE_rcv:
+		pc = executeSkipIf_rcv[W, util.GreaterThanOrEqual[W]](pc, codes, pool, stack)
+	case encoding.WIDE_RD_ROM_nm:
+		pc = executeReadRom_sn(pc, codes, stack, p.roms)
+	case encoding.WIDE_RD_SROM_nm:
+		pc = executeReadSrom_sn(pc, codes, stack, p.sroms)
+	case encoding.WIDE_WR_WOM_nm:
+		pc = executeWriteWom_sn(pc, codes, stack, p.woms)
+	case encoding.WIDE_RD_RAM_nm:
+		pc = executeReadRam_sn(pc, codes, stack, p.rams)
+	case encoding.WIDE_WR_RAM_nm:
+		pc = executeWriteRam_sn(pc, codes, stack, p.rams)
+	case encoding.WIDE_RD_PRAM_nm:
+		pc = executeReadPagedRam_sn(pc, codes, stack, p.prams)
+	case encoding.WIDE_WR_PRAM_nm:
+		pc = executeWritePagedRam_sn(pc, codes, stack, p.prams)
+	case encoding.WIDE_ADD_2n1:
+		pc, err = executeAdd_2n1(pc, codes, stack)
+	case encoding.WIDE_SUB_2n1:
+		pc, err = p.executeSub_2n1(pc, codes, stack)
+	case encoding.WIDE_MUL_2n1:
+		pc, err = executeMul_2n1(pc, codes, stack)
+	case encoding.WIDE_ADDC:
+		pc, err = executeAdd_1n1c(pc, codes, pool, stack)
+	case encoding.WIDE_SUBC:
+		pc, err = p.executeSub_1n1c(pc, codes, pool, stack)
+	case encoding.WIDE_MULC:
+		pc, err = executeMul_1n1c(pc, codes, pool, stack)
+	case encoding.WIDE_ADD_nm:
+		pc, err = p.executeAdd_nm(pc, codes, pool, stack)
+	case encoding.WIDE_SUB_nm:
+		pc, err = p.executeSub_nm(pc, codes, pool, stack)
+	case encoding.WIDE_MUL_nm:
+		pc, err = p.executeMul_nm(pc, codes, pool, stack)
+	case encoding.WIDE_DIV:
+		pc, err = executeDiv(pc, codes, stack)
+	case encoding.WIDE_REM:
+		pc, err = executeRem(pc, codes, stack)
+	case encoding.WIDE_INTRINSIC:
+		pc, err = p.executeIntrinsic(pc, codes, stack)
+	case encoding.WIDE_ADDMOD_P:
+		pc, err = p.executeFieldAdd(pc, codes, pool, stack)
+	case encoding.WIDE_SUBMOD_P:
+		pc, err = p.executeFieldSub(pc, codes, pool, stack)
+	case encoding.WIDE_MULMOD_P:
+		pc, err = p.executeFieldMul(pc, codes, pool, stack)
+	case encoding.WIDE_AND:
+		pc, err = executeAnd(pc, codes, stack)
+	case encoding.WIDE_OR:
+		pc, err = executeOr(pc, codes, stack)
+	case encoding.WIDE_XOR:
+		pc, err = executeXor(pc, codes, stack)
+	case encoding.WIDE_NOT:
+		pc, err = executeNot(pc, codes, stack)
+	case encoding.WIDE_SHL:
+		pc, err = executeShl(pc, codes, stack)
+	case encoding.WIDE_SHR:
+		pc, err = executeShr(pc, codes, stack)
+	case encoding.WIDE_CAT:
+		pc, err = p.executeCat(pc, codes, stack)
+	case encoding.WIDE_UINT_TO_FIELD:
+		pc, err = p.executeUintToField(pc, codes, stack)
+	case encoding.WIDE_FIELD_TO_UINT:
+		pc, err = p.executeFieldToUint(pc, codes, stack)
+	default:
+		err = fmt.Errorf("unknown wide bytecode encountered (0x%x)", wopcode)
+	}
+	//
+	return pc, false, err
 }
 
 // initialise prepares all memories for a fresh execution.  Input (read-only and

--- a/pkg/zkc/vm/internal/interpreter/interpreter.go
+++ b/pkg/zkc/vm/internal/interpreter/interpreter.go
@@ -766,7 +766,7 @@ func (p *Interpreter[W]) executeWide(pc uint32, codes []uint32, pool []W, stack 
 	case encoding.WIDE_FAIL:
 		return pc, true, p.executeFail(pc, codes, stack)
 	case encoding.WIDE_CHECKCAST:
-		pc, err = executeCheckCast(pc, codes, stack)
+		pc, err = p.executeCheckCast(pc, codes, stack)
 	case encoding.WIDE_DEBUG:
 		pc = p.executeDebug(pc, codes, stack)
 	case encoding.WIDE_LDC_w:
@@ -824,17 +824,17 @@ func (p *Interpreter[W]) executeWide(pc uint32, codes []uint32, pool []W, stack 
 	case encoding.WIDE_WR_PRAM_nm:
 		pc = executeWritePagedRam_sn(pc, codes, stack, p.prams)
 	case encoding.WIDE_ADD_2n1:
-		pc, err = executeAdd_2n1(pc, codes, stack)
+		pc, err = p.executeAdd_2n1(pc, codes, stack)
 	case encoding.WIDE_SUB_2n1:
 		pc, err = p.executeSub_2n1(pc, codes, stack)
 	case encoding.WIDE_MUL_2n1:
-		pc, err = executeMul_2n1(pc, codes, stack)
+		pc, err = p.executeMul_2n1(pc, codes, stack)
 	case encoding.WIDE_ADDC:
-		pc, err = executeAdd_1n1c(pc, codes, pool, stack)
+		pc, err = p.executeAdd_1n1c(pc, codes, pool, stack)
 	case encoding.WIDE_SUBC:
 		pc, err = p.executeSub_1n1c(pc, codes, pool, stack)
 	case encoding.WIDE_MULC:
-		pc, err = executeMul_1n1c(pc, codes, pool, stack)
+		pc, err = p.executeMul_1n1c(pc, codes, pool, stack)
 	case encoding.WIDE_ADD_nm:
 		pc, err = p.executeAdd_nm(pc, codes, pool, stack)
 	case encoding.WIDE_SUB_nm:
@@ -842,9 +842,9 @@ func (p *Interpreter[W]) executeWide(pc uint32, codes []uint32, pool []W, stack 
 	case encoding.WIDE_MUL_nm:
 		pc, err = p.executeMul_nm(pc, codes, pool, stack)
 	case encoding.WIDE_DIV:
-		pc, err = executeDiv(pc, codes, stack)
+		pc, err = p.executeDiv(pc, codes, stack)
 	case encoding.WIDE_REM:
-		pc, err = executeRem(pc, codes, stack)
+		pc, err = p.executeRem(pc, codes, stack)
 	case encoding.WIDE_INTRINSIC:
 		pc, err = p.executeIntrinsic(pc, codes, stack)
 	case encoding.WIDE_ADDMOD_P:

--- a/pkg/zkc/vm/internal/interpreter/interpreter.go
+++ b/pkg/zkc/vm/internal/interpreter/interpreter.go
@@ -572,6 +572,7 @@ func (p *Interpreter[W]) Execute(steps uint) (uint, error) {
 		err       error
 		frame     []W = p.dataStack.SliceEnd(uint(p.fp))
 		bytecodes     = p.program.Bytecodes()
+		pool          = p.program.Constants()
 	)
 	//
 	for nsteps < steps && err == nil {
@@ -597,7 +598,7 @@ func (p *Interpreter[W]) Execute(steps uint) (uint, error) {
 		case encoding.LDC:
 			p.pc = executeLdc_1(p.pc, bytecodes, frame)
 		case encoding.LDC_w:
-			p.pc = executeLdc_w(p.pc, bytecodes, frame)
+			p.pc = executeLdc_w(p.pc, bytecodes, pool, frame)
 		case encoding.MOVE:
 			p.pc = executeMove_1s1(p.pc, bytecodes, frame)
 		case encoding.ENTER_n:
@@ -630,7 +631,7 @@ func (p *Interpreter[W]) Execute(steps uint) (uint, error) {
 		case encoding.SGE_rr:
 			p.pc = executeSkipIf_rr[W, util.GreaterThanOrEqual[W]](p.pc, bytecodes, frame)
 		case encoding.SKIP_M:
-			p.pc = executeSkipTable(p.pc, bytecodes, frame)
+			p.pc = executeSkipTable(p.pc, bytecodes, pool, frame)
 		case encoding.SKIP_B:
 			p.pc = executeDispatch(p.pc, bytecodes, frame)
 		case encoding.SEQ_rv:
@@ -642,21 +643,21 @@ func (p *Interpreter[W]) Execute(steps uint) (uint, error) {
 		case encoding.SGE_rv:
 			p.pc = executeSkipIf_rv[W, util.GreaterThanOrEqual[W]](p.pc, bytecodes, frame)
 		case encoding.SEQ_rc:
-			p.pc = executeSkipIf_rc[W, util.Equal[W]](p.pc, bytecodes, frame)
+			p.pc = executeSkipIf_rc[W, util.Equal[W]](p.pc, bytecodes, pool, frame)
 		case encoding.SNE_rc:
-			p.pc = executeSkipIf_rc[W, util.NotEqual[W]](p.pc, bytecodes, frame)
+			p.pc = executeSkipIf_rc[W, util.NotEqual[W]](p.pc, bytecodes, pool, frame)
 		case encoding.SLT_rc:
-			p.pc = executeSkipIf_rc[W, util.LessThan[W]](p.pc, bytecodes, frame)
+			p.pc = executeSkipIf_rc[W, util.LessThan[W]](p.pc, bytecodes, pool, frame)
 		case encoding.SGE_rc:
-			p.pc = executeSkipIf_rc[W, util.GreaterThanOrEqual[W]](p.pc, bytecodes, frame)
+			p.pc = executeSkipIf_rc[W, util.GreaterThanOrEqual[W]](p.pc, bytecodes, pool, frame)
 		case encoding.SEQ_rcv:
-			p.pc = executeSkipIf_rcv[W, util.Equal[W]](p.pc, bytecodes, frame)
+			p.pc = executeSkipIf_rcv[W, util.Equal[W]](p.pc, bytecodes, pool, frame)
 		case encoding.SNE_rcv:
-			p.pc = executeSkipIf_rcv[W, util.NotEqual[W]](p.pc, bytecodes, frame)
+			p.pc = executeSkipIf_rcv[W, util.NotEqual[W]](p.pc, bytecodes, pool, frame)
 		case encoding.SLT_rcv:
-			p.pc = executeSkipIf_rcv[W, util.LessThan[W]](p.pc, bytecodes, frame)
+			p.pc = executeSkipIf_rcv[W, util.LessThan[W]](p.pc, bytecodes, pool, frame)
 		case encoding.SGE_rcv:
-			p.pc = executeSkipIf_rcv[W, util.GreaterThanOrEqual[W]](p.pc, bytecodes, frame)
+			p.pc = executeSkipIf_rcv[W, util.GreaterThanOrEqual[W]](p.pc, bytecodes, pool, frame)
 			// Input / Output Operations
 		case encoding.RD_ROM_nm:
 			p.pc = executeReadRom_sn(p.pc, bytecodes, frame, p.roms)
@@ -676,21 +677,21 @@ func (p *Interpreter[W]) Execute(steps uint) (uint, error) {
 		case encoding.ADD_2n1:
 			p.pc, err = p.executeAdd_2n1(p.pc, bytecodes, frame)
 		case encoding.ADDC:
-			p.pc, err = p.executeAdd_1n1c(p.pc, bytecodes, frame)
+			p.pc, err = p.executeAdd_1n1c(p.pc, bytecodes, pool, frame)
 		case encoding.SUB_2n1:
 			p.pc, err = p.executeSub_2n1(p.pc, bytecodes, frame)
 		case encoding.SUBC:
-			p.pc, err = p.executeSub_1n1c(p.pc, bytecodes, frame)
+			p.pc, err = p.executeSub_1n1c(p.pc, bytecodes, pool, frame)
 		case encoding.MUL_2n1:
 			p.pc, err = p.executeMul_2n1(p.pc, bytecodes, frame)
 		case encoding.MULC:
-			p.pc, err = p.executeMul_1n1c(p.pc, bytecodes, frame)
+			p.pc, err = p.executeMul_1n1c(p.pc, bytecodes, pool, frame)
 		case encoding.ADD_nm:
-			p.pc, err = p.executeAdd_nm(p.pc, bytecodes, frame)
+			p.pc, err = p.executeAdd_nm(p.pc, bytecodes, pool, frame)
 		case encoding.SUB_nm:
-			p.pc, err = p.executeSub_nm(p.pc, bytecodes, frame)
+			p.pc, err = p.executeSub_nm(p.pc, bytecodes, pool, frame)
 		case encoding.MUL_nm:
-			p.pc, err = p.executeMul_nm(p.pc, bytecodes, frame)
+			p.pc, err = p.executeMul_nm(p.pc, bytecodes, pool, frame)
 		case encoding.DIV:
 			p.pc, err = p.executeDiv(p.pc, bytecodes, frame)
 		case encoding.REM:
@@ -698,11 +699,11 @@ func (p *Interpreter[W]) Execute(steps uint) (uint, error) {
 		case encoding.INTRINSIC:
 			p.pc, err = p.executeIntrinsic(p.pc, bytecodes, frame)
 		case encoding.ADDMOD_P:
-			p.pc, err = p.executeFieldAdd(p.pc, bytecodes, frame)
+			p.pc, err = p.executeFieldAdd(p.pc, bytecodes, pool, frame)
 		case encoding.SUBMOD_P:
-			p.pc, err = p.executeFieldSub(p.pc, bytecodes, frame)
+			p.pc, err = p.executeFieldSub(p.pc, bytecodes, pool, frame)
 		case encoding.MULMOD_P:
-			p.pc, err = p.executeFieldMul(p.pc, bytecodes, frame)
+			p.pc, err = p.executeFieldMul(p.pc, bytecodes, pool, frame)
 		case encoding.CAT:
 			p.pc, err = p.executeCat(p.pc, bytecodes, frame)
 		case encoding.UINT_TO_FIELD:
@@ -821,9 +822,9 @@ func (p *Interpreter[W]) executeReturn(pc uint32, codes []uint32) (uint32, error
 // executeAdd_nm implements ADD_nm: it sums the constant and all sources and
 // stores the result across a vector target using the same low-limb-first rule
 // as the word machine, reporting an error on overflow.
-func (p *Interpreter[W]) executeAdd_nm(pc uint32, codes []uint32, stack []W) (uint32, error) {
+func (p *Interpreter[W]) executeAdd_nm(pc uint32, codes []uint32, pool []W, stack []W) (uint32, error) {
 	var (
-		targets, sources, constant, _, n = encoding.DecodeArith_nm[W](pc, codes)
+		targets, sources, constant, _, n = encoding.DecodeArith_nm[W](pc, codes, pool)
 		val                              = constant
 	)
 	//
@@ -846,9 +847,9 @@ func (p *Interpreter[W]) executeAdd_nm(pc uint32, codes []uint32, stack []W) (ui
 // executeMul_nm implements MUL_nm: it multiplies the constant by all sources
 // and stores the result across a vector target using the same low-limb-first
 // rule as the word machine, reporting an error on overflow.
-func (p *Interpreter[W]) executeMul_nm(pc uint32, codes []uint32, stack []W) (uint32, error) {
+func (p *Interpreter[W]) executeMul_nm(pc uint32, codes []uint32, pool []W, stack []W) (uint32, error) {
 	var (
-		targets, sources, constant, _, n = encoding.DecodeArith_nm[W](pc, codes)
+		targets, sources, constant, _, n = encoding.DecodeArith_nm[W](pc, codes, pool)
 		val                              = constant
 		overflow                         bool
 	)
@@ -874,9 +875,9 @@ func (p *Interpreter[W]) executeMul_nm(pc uint32, codes []uint32, stack []W) (ui
 // executeFieldAdd implements ADDMOD_P: it sums the constant and all sources
 // modulo the field's prime characteristic, storing the (reduced) result in the
 // single target register.  Matches executeFieldAdd in the slow word machine.
-func (p *Interpreter[W]) executeFieldAdd(pc uint32, codes []uint32, stack []W) (uint32, error) {
+func (p *Interpreter[W]) executeFieldAdd(pc uint32, codes []uint32, pool []W, stack []W) (uint32, error) {
 	var (
-		rd, sources, constant, n = encoding.DecodeFieldArithOperands[W](pc, codes)
+		rd, sources, constant, n = encoding.DecodeFieldArithOperands[W](pc, codes, pool)
 		val                      = constant
 	)
 	//
@@ -893,9 +894,9 @@ func (p *Interpreter[W]) executeFieldAdd(pc uint32, codes []uint32, stack []W) (
 // then subtracts the remaining sources and the constant modulo the field's
 // prime characteristic, storing the (reduced) result in the single target
 // register.  Matches executeFieldSub in the slow word machine.
-func (p *Interpreter[W]) executeFieldSub(pc uint32, codes []uint32, stack []W) (uint32, error) {
+func (p *Interpreter[W]) executeFieldSub(pc uint32, codes []uint32, pool []W, stack []W) (uint32, error) {
 	var (
-		rd, sources, constant, n = encoding.DecodeFieldArithOperands[W](pc, codes)
+		rd, sources, constant, n = encoding.DecodeFieldArithOperands[W](pc, codes, pool)
 		val                      W
 	)
 	//
@@ -917,9 +918,9 @@ func (p *Interpreter[W]) executeFieldSub(pc uint32, codes []uint32, stack []W) (
 // executeFieldMul implements MULMOD_P: it multiplies the constant by all sources
 // modulo the field's prime characteristic, storing the (reduced) result in the
 // single target register.  Matches executeFieldMul in the slow word machine.
-func (p *Interpreter[W]) executeFieldMul(pc uint32, codes []uint32, stack []W) (uint32, error) {
+func (p *Interpreter[W]) executeFieldMul(pc uint32, codes []uint32, pool []W, stack []W) (uint32, error) {
 	var (
-		rd, sources, constant, n = encoding.DecodeFieldArithOperands[W](pc, codes)
+		rd, sources, constant, n = encoding.DecodeFieldArithOperands[W](pc, codes, pool)
 		val                      = constant
 	)
 	//
@@ -1066,9 +1067,9 @@ func (p *Interpreter[W]) executeAdd_2n1(pc uint32, codes []uint32, stack []W) (u
 }
 
 // executeAdd_1n1c implements ADDC: stack[rd] = stack[rs] + constant.
-func (p *Interpreter[W]) executeAdd_1n1c(pc uint32, codes []uint32, stack []W) (uint32, error) {
+func (p *Interpreter[W]) executeAdd_1n1c(pc uint32, codes []uint32, pool []W, stack []W) (uint32, error) {
 	var (
-		rs, rd, constant, n = encoding.DecodeArith_1n1c[W](pc, codes)
+		rs, rd, constant, n = encoding.DecodeArith_1n1c[W](pc, codes, pool)
 		val                 = stack[rs]
 		res, overflow       = val.Add(constant)
 	)
@@ -1583,11 +1584,12 @@ func executeSkipIf_rr[W word.Word[W], F util.Comparator[W]](pc uint32, codes []u
 // If stack[rs0] compares to the inline constant as required, execution skips
 // forward to the encoded target; otherwise it falls through to the following
 // bytecode.
-func executeSkipIf_rc[W word.Word[W], F util.Comparator[W]](pc uint32, codes []uint32, stack []W) uint32 {
+func executeSkipIf_rc[W word.Word[W], F util.Comparator[W]](pc uint32, codes []uint32, pool []W,
+	stack []W) uint32 {
 	var (
 		c F
 		//
-		skip, rs0, constant, _, n = encoding.DecodeSkipIf_rc[W](pc, codes)
+		skip, rs0, constant, _, n = encoding.DecodeSkipIf_rc[W](pc, codes, pool)
 		// Calculate skip target
 		target = pc + 1 + skip
 		// Read rs0
@@ -1608,11 +1610,12 @@ func executeSkipIf_rc[W word.Word[W], F util.Comparator[W]](pc uint32, codes []u
 // by adjusting the constant (x > c ⇔ x >= c+1).  The comparison is selected
 // via the Comparator type parameter F, and proceeds lexicographically from the
 // most-significant element (base) downwards, exactly as executeSkipIf_rv.
-func executeSkipIf_rcv[W word.Word[W], F util.Comparator[W]](pc uint32, codes []uint32, stack []W) uint32 {
+func executeSkipIf_rcv[W word.Word[W], F util.Comparator[W]](pc uint32, codes []uint32, pool []W,
+	stack []W) uint32 {
 	var (
 		cmp F
 		//
-		skip, rs0, constants, _, n = encoding.DecodeSkipIf_rcv[W](pc, codes)
+		skip, rs0, constants, _, n = encoding.DecodeSkipIf_rcv[W](pc, codes, pool)
 		// Calculate skip target
 		target = pc + 1 + skip
 	)
@@ -1680,7 +1683,7 @@ func executeSkipIf_rv[W word.Word[W], F util.Comparator[W]](pc uint32, codes []u
 // compared against each case value and, on the first match, control transfers
 // to that case's (absolute) target; otherwise control falls through past the
 // whole instruction to the following one.
-func executeSkipTable[W word.Word[W]](pc uint32, codes []uint32, stack []W) uint32 {
+func executeSkipTable[W word.Word[W]](pc uint32, codes []uint32, pool []W, stack []W) uint32 {
 	var (
 		word0  = codes[pc]
 		count  = (word0 >> 24) & 0xff
@@ -1689,17 +1692,14 @@ func executeSkipTable[W word.Word[W]](pc uint32, codes []uint32, stack []W) uint
 	)
 	//
 	for i := range count {
-		var (
-			base  = pc + 1 + (i * 3)
-			value = uint64(codes[base]) | (uint64(codes[base+1]) << 32)
-		)
+		var word = codes[pc+1+i]
 		//
-		if val.Cmp64(value) == 0 {
-			return codes[base+2]
+		if val.Cmp(pool[word&0xffff]) == 0 {
+			return pc + 1 + (word >> 16)
 		}
 	}
 	// no match: fall through past the whole instruction
-	return pc + 1 + (3 * count)
+	return pc + 1 + count
 }
 
 // executeDispatch implements the SKIP_B (one-hot) dispatch: the case bits are
@@ -1713,14 +1713,14 @@ func executeDispatch[W word.Word[W]](pc uint32, codes []uint32, stack []W) uint3
 	)
 	//
 	for i := range count {
-		var base = pc + 1 + (i * 2)
+		var word = codes[pc+1+i]
 		//
-		if stack[codes[base]].Cmp64(0) != 0 {
-			return codes[base+1]
+		if stack[word&0xffff].Cmp64(0) != 0 {
+			return pc + 1 + (word >> 16)
 		}
 	}
 	// no bit set: fall through past the whole instruction
-	return pc + 1 + (2 * count)
+	return pc + 1 + count
 }
 
 // executeLdc_1 implements LDC: it loads a constant value into register rd.
@@ -1734,8 +1734,8 @@ func executeLdc_1[W word.Word[W]](pc uint32, codes []uint32, stack []W) uint32 {
 
 // executeLdc_w implements LDC_w: it loads a wide constant value into register
 // rd.
-func executeLdc_w[W word.Word[W]](pc uint32, codes []uint32, stack []W) uint32 {
-	val, rd, n := encoding.DecodeLdc_w[W](pc, codes)
+func executeLdc_w[W word.Word[W]](pc uint32, codes []uint32, pool []W, stack []W) uint32 {
+	val, rd, n := encoding.DecodeLdc_w[W](pc, codes, pool)
 	//
 	stack[rd] = val
 	//
@@ -1779,9 +1779,9 @@ func (p *Interpreter[W]) executeMul_2n1(pc uint32, codes []uint32, stack []W) (u
 }
 
 // executeMul_1n1c implements MULC: stack[rd] = stack[rs] * constant.
-func (p *Interpreter[W]) executeMul_1n1c(pc uint32, codes []uint32, stack []W) (uint32, error) {
+func (p *Interpreter[W]) executeMul_1n1c(pc uint32, codes []uint32, pool []W, stack []W) (uint32, error) {
 	var (
-		rs, rd, constant, n = encoding.DecodeArith_1n1c[W](pc, codes)
+		rs, rd, constant, n = encoding.DecodeArith_1n1c[W](pc, codes, pool)
 		val                 = stack[rs]
 		hi, lo              = val.Mul(constant)
 	)
@@ -1876,9 +1876,9 @@ func executeShr[W word.Word[W]](pc uint32, codes []uint32, stack []W) (uint32, e
 }
 
 // executeSub_1n1c implements SUBC: stack[rd] = stack[rs] - constant.
-func (p *Interpreter[W]) executeSub_1n1c(pc uint32, codes []uint32, stack []W) (uint32, error) {
+func (p *Interpreter[W]) executeSub_1n1c(pc uint32, codes []uint32, pool []W, stack []W) (uint32, error) {
 	var (
-		rs, rd, constant, n = encoding.DecodeArith_1n1c[W](pc, codes)
+		rs, rd, constant, n = encoding.DecodeArith_1n1c[W](pc, codes, pool)
 		val                 = stack[rs]
 		res, underflow      = val.Sub(constant)
 	)
@@ -1939,9 +1939,9 @@ func (p *Interpreter[W]) executeSub_2n1(pc uint32, codes []uint32, stack []W) (u
 // subtracts the remaining sources and the constant, and stores the result
 // across a vector target using the same low-limb-first rule as the word
 // machine, reporting an error on underflow.
-func (p *Interpreter[W]) executeSub_nm(pc uint32, codes []uint32, stack []W) (uint32, error) {
+func (p *Interpreter[W]) executeSub_nm(pc uint32, codes []uint32, pool []W, stack []W) (uint32, error) {
 	var (
-		targets, sources, constant, bitwidth, n = encoding.DecodeArith_nm[W](pc, codes)
+		targets, sources, constant, bitwidth, n = encoding.DecodeArith_nm[W](pc, codes, pool)
 		val                                     W
 		acc                                     W
 		underflow                               bool

--- a/pkg/zkc/vm/trace.go
+++ b/pkg/zkc/vm/trace.go
@@ -57,7 +57,7 @@ func BootAndTrace[W Word[W], F Element[F]](p Program[W], in map[string][]byte, n
 		// Extract state from the interpreter
 		fid, pc, frame := interpreter.ExtractExecutingState(bci)
 		// Check whether terminating state
-		terminal := opcode == encoding.RET
+		terminal := opcode == encoding.RET || opcode == encoding.WIDE|encoding.WIDE_RET<<8
 		// NOTE: don't clone the frame here (for now) since it is always
 		// converted into a slice of field elements F.
 		tracer.TraceFunctionLine(State[W]{fid, pc, terminal, frame})


### PR DESCRIPTION
This PR tweakings the interpreter encodings to free up more opcode space.  This is done by introducing `u16` "wide opcodes" which are triggered by a small opcode `0xff`.  Thus, short-form encodings are unaffected whilst wide encodings have a minor performance impact.