### PR TITLE
docs: record the LowerSwitch ordering constraint it now relies on

### DIFF
--- a/pkg/zkc/vm/internal/transform/factor_skip_conditions.go
+++ b/pkg/zkc/vm/internal/transform/factor_skip_conditions.go
@@ -94,9 +94,17 @@ func factorableSkips[W word.Word[W]](codes []Bytecode[W], registers split.Alloca
 			factor[uint(i)] = false
 			continue
 		}
-		// Nothing to factorize if the body of the skip is a bit equality like b = x == 0 ? 1 :0.
-		// Note that as we lowerSwitch later, this pattern can't arise from lowerSwitch, but only
-		// directly from .zkc program.
+		// Nothing to factorize when the body is already a bit-select diamond, as
+		// written directly in .zkc by e.g. "b = x == 0 ? 1 : 0": it computes the
+		// very guard bit that factoring would introduce.
+		//
+		// NOTE: the shape is not unique to hand-written .zkc.  LowerSwitch emits
+		// one such diamond per case, and FactorLimbEqualities one per limb;
+		// neither reaches us, because both run later (see codegen/compile.go, and
+		// the ordering note on LowerSwitch).  factorSkipIf below emits it too,
+		// but its output is never re-examined, since factor[] is decided over the
+		// original vector.  Were that ordering to change, we would merely decline
+		// a factorisation which was not needed: no correctness impact.
 		if bodyContainsOnlyBitEquality(codes, uint(i), registers) {
 			factor[uint(i)] = false
 			continue

--- a/pkg/zkc/vm/transform.go
+++ b/pkg/zkc/vm/transform.go
@@ -82,7 +82,10 @@ func LowerDivisions[W word.Word[W]](program Program[W]) Program[W] {
 // through exactly as before.
 //
 // NOTE: this transform must run before register splitting (which does not
-// support Switch bytecodes).
+// support Switch bytecodes), and after FactorSkipConditions: it emits one
+// bit-select diamond per case, which that pass would otherwise re-factor for no
+// gain (see bodyContainsOnlyBitEquality, whose reasoning assumes these diamonds
+// have not been introduced yet).
 func LowerSwitch[W word.Word[W]](program Program[W]) Program[W] {
 	return transform.LowerSwitch(program)
 }


### PR DESCRIPTION
Follow-up to #2095 — comments only, no behavioural change.

## Why

`bodyContainsOnlyBitEquality` carries this justification:

> Note that as we lowerSwitch later, this pattern can't arise from lowerSwitch, but only directly from .zkc program.

Two problems with it:

1. **The first half is true only by pass ordering** — which #2095 itself changed. Nothing enforces it, and nothing fails if it is broken again.
2. **The second half is not accurate.** The shape is not unique to hand-written `.zkc`:
   - `LowerSwitch` emits exactly it, one diamond per case (see its own doc: `if x == 1 {b_1 = 1} else {b_1 = 0}`);
   - `FactorLimbEqualities` emits one per limb;
   - `factorSkipIf`, in the same file, emits it too (though its output is never re-examined, since `factor[]` is decided over the original vector).

   None of them reaches the check today — purely because all three run later in the pipeline.

## What

- Reword the comment to state the **dependency** rather than an impossibility, and note that breaking it costs only an unnecessary factorisation, not correctness. (That is worth saying: it tells the next reader this is a perf guard, so a stale assumption here is cheap.)
- Add the new requirement to `LowerSwitch`'s doc, next to the `must run before register splitting` note it already carries. That is where someone reordering the pass will actually look; without it, moving `LowerSwitch` back above `FactorSkipConditions` would satisfy every documented constraint while silently invalidating the reasoning in the other file — and nothing would fail to signal it.

## Verification

Comment-only (the diff contains no non-comment lines). `go build ./...` and `golangci-lint run pkg/zkc/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)