### PR TITLE
feat: support transformation pipelines

### DIFF
--- a/pkg/cmd/zkc/build.go
+++ b/pkg/cmd/zkc/build.go
@@ -22,47 +22,33 @@ import (
 	"github.com/LFDT-Lineth/zkc/pkg/util/source"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/compiler/ast"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/compiler/codegen"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/constraints"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm"
 	log "github.com/sirupsen/logrus"
 )
-
-// BuildArtifacts captures the set of outputs generated from compiling a given
-// ZkC program (e.g. AIR constraints).  Whilst the AIR artifact might be
-// considered the primary goal of compilation, the other artifacts are needed to
-// support other features.  For example, the FIR artifact is needed for trace
-// expansion, whilst the AST artifact allows the AST to be printed for debugging
-// purposes.
-type BuildArtifacts struct {
-	// Abstract Syntax Tree
-	ast util.Option[ast.Program]
-	// Word Machine
-	ir vm.Program[vm.Uint]
-	// Annotations on source-level declarations (functions and memories),
-	// keyed by declaration name.  These are not carried through to the lower
-	// levels, hence they are retained here for printing purposes.  Observe
-	// this is empty when building from a prebuilt binary.
-	annotations map[string][]string
-}
 
 // BuildConfig packages up all the requirements for building the set of target
 // artifacts.
 type BuildConfig struct {
 	// code configuration includes various things which can be turned off / on.
 	config codegen.Config
+	// fast mode determination
+	fastMode bool
 	// metadata to include in binary output file
-	metadata []byte
+	metadata util.Option[[]byte]
 	// enable go code generator
 	gogen bool
 	// padding strategy
 	padding ir.PaddingStrategy
+	// ignored pipeline stages
+	ignores []string
 }
 
 // Build applies a build configuration with a given set of source files.
-func Build[F field.Element[F]](build BuildConfig, args ...string) BuildArtifacts {
+func Build[F field.Element[F]](build BuildConfig, args ...string) (*ast.Program, *constraints.BinaryFile[F]) {
 	var (
 		errs []source.SyntaxError
-		//
-		artifacts BuildArtifacts
+		raw  vm.Program[vm.Uint]
 	)
 	// Check whether prebuilt binary supplied on command-line.
 	if len(args) > 0 && path.Ext(args[0]) == ".bin" {
@@ -71,45 +57,31 @@ func Build[F field.Element[F]](build BuildConfig, args ...string) BuildArtifacts
 			log.Error("require exactly one prebuilt binary")
 			os.Exit(6)
 		}
+		//
+		var (
+			// Read existing binary file
+			binf = ReadBinaryFile[F](args[0])
+			// Determine metadata
+			metadata = build.metadata.UnwrapOr(binf.Header().MetaData)
+		)
 		// Single (binary) file supplied
-		artifacts.ir = ReadBinaryFile[F](args[0]).Program()
-	} else {
-		var ir vm.Program[vm.Uint]
-		// Compile source files, or print errors
-		prog := CompileSourceFiles(build.config.GetField(), args...)
-		// Record AST (e.g. for debugging)
-		artifacts.ast = util.Some(prog)
-		// Record annotations for printing purposes
-		artifacts.annotations = annotationsOf(prog)
-		// Word-level Intermediate Representation
-		// Compile the AST into the top-level word machine
-		ir, errs = ast.Compile(prog, build.config)
-		//
-		artifacts.ir = ir
-		//
-		if len(errs) > 0 {
-			for _, err := range errs {
-				printSyntaxError(&err)
-			}
-			//
-			os.Exit(4)
+		return nil, constraints.NewBinaryFile[F](metadata, binf.Attributes(), binf.RawProgram()).
+			WithIgnores(build.ignores...)
+	}
+	// Compile source files, or print errors
+	prog := CompileSourceFiles(build.config.GetField(), args...)
+	// Word-level Intermediate Representation
+	// Compile the AST into the top-level word machine
+	raw, errs = ast.Compile(prog, build.config)
+	//
+	if len(errs) > 0 {
+		for _, err := range errs {
+			printSyntaxError(&err)
 		}
+		//
+		os.Exit(4)
 	}
 	//
-	return artifacts
-}
-
-// annotationsOf extracts the annotations associated with each annotated
-// declaration (i.e. function or memory) in a given program, keyed by the
-// declaration's name.
-func annotationsOf(program ast.Program) map[string][]string {
-	var annotations = make(map[string][]string)
-	//
-	for _, d := range program.Components() {
-		if annots := d.Annotations(); len(annots) > 0 {
-			annotations[d.Name()] = annots
-		}
-	}
-	//
-	return annotations
+	return &prog, constraints.NewBinaryFile[F](build.metadata.UnwrapOr(nil), nil, raw).
+		WithIgnores(build.ignores...)
 }

--- a/pkg/cmd/zkc/compile.go
+++ b/pkg/cmd/zkc/compile.go
@@ -20,6 +20,7 @@ import (
 	"github.com/LFDT-Lineth/zkc/pkg/cmd/corset/debug"
 	"github.com/LFDT-Lineth/zkc/pkg/util"
 	"github.com/LFDT-Lineth/zkc/pkg/util/collection/array"
+	"github.com/LFDT-Lineth/zkc/pkg/util/collection/typed"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field/bls12_377"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field/gf251"
@@ -64,8 +65,8 @@ type CompileConfig struct {
 	build BuildConfig
 	// indicates whether or not to print the Abstract Syntax Tree (when available)
 	ast bool
-	// indicates whether or not to print the Intermediate Reprentation
-	ir bool
+	// indicates whether or not to print the raw Intermediate Reprentation
+	raw bool
 	// indicates whether or not to print the Mid-level Intermediate Reprentation (MIR).
 	mir bool
 	// indicates whether or not to print the Mid-level Intermediate Reprentation (AIR).
@@ -90,45 +91,71 @@ func runCompileCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 	// Sanity check permitted flag combinations
 	checkFlags(cmd, compileFlags)
 	//
-	config.build = build
 	config.ast = GetFlag(cmd, "ast")
+	config.raw = GetFlag(cmd, "raw")
 	config.mir = GetFlag(cmd, "mir")
 	config.air = GetFlag(cmd, "air")
 	config.stats = GetFlag(cmd, "stats")
 	config.order = GetString(cmd, "order")
-	config.ir = !(config.ast || config.mir || config.air || config.stats)
 	// Compile verbosity is the highest verbosity level.
 	config.verbose = GetVerboseLevel(cmd) >= VERBOSE_PRINTF
+	// Configure metadata for the binary output file.  Observe this is left
+	// unset (rather than empty) when no definitions are given, so that metadata
+	// embedded in a prebuilt binary is preserved.
+	if cmd.Flags().Changed("define") {
+		build.metadata = util.Some(buildMetadata(GetStringArray(cmd, "define")))
+	}
+	//
+	config.build = build
 	// Build all artifacts
-	artifacts := Build[F](build, args...)
+	ast, binfile := Build[F](build, args...)
+	// Perform validation.  This comes before anything is printed or written, so
+	// that an invalid set of constraints cannot leave a binary file behind.
+	validateArtifacts(binfile)
 	//
 	if output != "" {
-		writeArtifacts[F](output, build, artifacts)
+		// Write to disk
+		WriteBinaryFile(binfile, output)
 	} else {
 		// Print out requested artifacts
-		printArtifacts[F](field, artifacts, config)
+		printArtifacts(ast, binfile, config)
 	}
-	// perform validation
-	validateArtifacts[F](field, artifacts, config)
 }
 
-func writeArtifacts[F field.Element[F]](filename string, build BuildConfig, artifacts BuildArtifacts) {
-	// Construct binary file
-	var binfile = constraints.NewBinaryFile[F](build.metadata, nil, build.config.GetField(),
-		build.config.GetMaxStaticHeight(), artifacts.ir)
-	// Write to disk
-	WriteBinaryFile(binfile, filename)
+// buildMetadata converts a set of "key=value" definitions, as given on the
+// command-line via -D, into the JSON blob embedded in the binary file header.
+func buildMetadata(items []string) []byte {
+	var metadata = make(map[string]any)
+	//
+	for _, item := range items {
+		key, value, ok := strings.Cut(item, "=")
+		//
+		if !ok {
+			fmt.Printf("malformed definition \"%s\"\n", item)
+			os.Exit(2)
+		}
+		//
+		metadata[key] = value
+	}
+	//
+	m := typed.NewMap(metadata)
+	//
+	bytes, err := m.ToJsonBytes()
+	if err != nil {
+		fmt.Printf("error encoding metadata: %s\n", err)
+		os.Exit(2)
+	}
+	//
+	return bytes
 }
 
 // Validate the given schema by ensuring that:
 // - every register in every module is referenced in at least one vanishing
 // constraint or lookup.
 // - static tables are of power of two height
-func validateArtifacts[F field.Element[F]](field field.Config, artifacts BuildArtifacts, config CompileConfig) {
-	// Generate AIR representation
-	air := constraints.GenerateAirConstraints[vm.Uint, F](artifacts.ir, field, config.build.config.GetMaxStaticHeight())
+func validateArtifacts[F field.Element[F]](bf *constraints.BinaryFile[F]) {
+	var air = bf.AirConstraints()
 	// validate that all registers are referenced in at least one vanishing constraint or lookup
-
 	if errs := constraints.Validate(air); len(errs) > 0 {
 		for _, err := range errs {
 			log.Errorf("%v", err)
@@ -138,34 +165,33 @@ func validateArtifacts[F field.Element[F]](field field.Config, artifacts BuildAr
 	}
 }
 
-func printArtifacts[F field.Element[F]](field field.Config, artifacts BuildArtifacts, config CompileConfig) {
-	// lower to a 64bit machine
-	var (
-		// Compile bytecode interpreter
-		bci = vm.ProgramToProgram[vm.Uint, vm.Uint128](artifacts.ir)
-	)
+func printArtifacts[F field.Element[F]](ast *ast.Program, bf *constraints.BinaryFile[F], config CompileConfig) {
+	// Determine whether or not to print the IR
+	var ir = !(config.ast || config.mir || config.air || config.stats)
 	// Abstract Syntax Tree
-	if config.ast && artifacts.ast.HasValue() {
-		writeAbstractSyntaxTree(artifacts.ast.Unwrap())
+	if config.ast && ast != nil {
+		writeAbstractSyntaxTree(*ast)
 	} else if config.ast {
 		log.Warn("Abstract Syntax Tree unavailable")
 	}
 	// Word-level Intermediate Representation
-	if config.ir {
-		// Bytecode Intermediate Representation
-		writeBytecodeProgram(config.verbose, bci, artifacts.annotations)
+	if ir && config.raw {
+		// Raw IR
+		writeBytecodeProgram(config.verbose, ast, bf.RawProgram())
+	} else if ir && config.build.fastMode {
+		// Execution IR
+		writeBytecodeProgram(config.verbose, ast, bf.ExecutionProgram())
+	} else if ir {
+		// Tracing IR
+		writeBytecodeProgram(config.verbose, ast, bf.TracingProgram())
 	}
 	// Mid-level Intermediate Representation
 	if config.mir {
-		mir := constraints.GenerateMirConstraints[vm.Uint, F](artifacts.ir, field, config.build.config.GetMaxStaticHeight())
-		//
-		debug.PrintAnySchema(mir, 80, config.verbose)
+		debug.PrintAnySchema(bf.MirConstraints(), 80, config.verbose)
 	}
-	// // Arithmetic Intermediate Representation
+	// Arithmetic Intermediate Representation
 	if config.air {
-		air := constraints.GenerateAirConstraints[vm.Uint, F](artifacts.ir, field, config.build.config.GetMaxStaticHeight())
-		//
-		debug.PrintAnySchema(air, 80, config.verbose)
+		debug.PrintAnySchema(bf.AirConstraints(), 80, config.verbose)
 	}
 	// Summary statistics
 	if config.stats {
@@ -173,19 +199,12 @@ func printArtifacts[F field.Element[F]](field field.Config, artifacts BuildArtif
 			log.Errorf("invalid --order %q (expected name|total|complexity|lookups)", config.order)
 			os.Exit(1)
 		}
-		//
-		air := constraints.GenerateAirConstraints[vm.Uint, F](artifacts.ir, field, config.build.config.GetMaxStaticHeight())
 		// Register counts are reported before register splitting.  Splitting is
 		// the only field-specific transform that changes register widths, so
-		// recompile the program with it disabled to recover the pre-split widths.
-		// When compiling from a prebuilt binary there is no AST to recompile, so
-		// fall back to the (already split) build.
-		preSplit := artifacts.ir
-		if artifacts.ast.HasValue() {
-			preSplit, _ = ast.Compile(artifacts.ast.Unwrap(), config.build.config.SplitRegisters(false))
-		}
-		//
-		PrintCompileStats(air, preSplit, config.order)
+		// transform program with splitting disabled to recover the pre-split widths.
+		preSplit := vm.TransformForTracing[vm.Uint, vm.Uint](bf.RawProgram(), "split-registers")
+		// Print stats
+		PrintCompileStats(bf.AirConstraints(), preSplit, config.order)
 	}
 }
 
@@ -513,11 +532,12 @@ func (p *bytecodeListing) table() *termio.FormattedTable {
 	return tbl
 }
 
-func writeBytecodeProgram[W vm.Word[W]](binary bool, program vm.Program[W], annotations map[string][]string) {
+func writeBytecodeProgram[W vm.Word[W]](binary bool, ast *ast.Program, program vm.Program[W]) {
 	var (
 		bin           [][]uint32
 		address       uint32
 		encodingWidth uint
+		annotations   = annotationsOf(ast)
 	)
 	//
 	if binary {
@@ -538,6 +558,23 @@ func writeBytecodeProgram[W vm.Word[W]](binary bool, program vm.Program[W], anno
 		// Write and print this module's table
 		address, bin = writeBytecodeModule(binary, encodingWidth, uint16(i), program, m, annotations, address, bin)
 	}
+}
+
+// annotationsOf extracts the annotations associated with each annotated
+// declaration (i.e. function or memory) in a given program, keyed by the
+// declaration's name.
+func annotationsOf(program *ast.Program) map[string][]string {
+	var annotations = make(map[string][]string)
+	//
+	if program != nil {
+		for _, d := range program.Components() {
+			if annots := d.Annotations(); len(annots) > 0 {
+				annotations[d.Name()] = annots
+			}
+		}
+	}
+	//
+	return annotations
 }
 
 // writeBytecodeModule builds and prints the FormattedTable for a single module.
@@ -738,8 +775,10 @@ func fnArgs[W vm.Word[W]](regs []vm.Register[W]) string {
 func init() {
 	rootCmd.AddCommand(compileCmd)
 	compileCmd.Flags().StringP("output", "o", "", "specify output file for writing binary constraints")
+	compileCmd.Flags().StringArrayP("define", "D", nil,
+		"define a metadata attribute (as \"key=value\") to embed in the binary output file")
 	compileCmd.PersistentFlags().Bool("ast", false, "Output Abstract Syntax Tree (AST)")
-	compileCmd.PersistentFlags().Bool("bci", false, "Output Bytecode Representation (BCI)")
+	compileCmd.PersistentFlags().Bool("raw", false, "Output raw Intermediate (Bytecode) Representation (IR)")
 	compileCmd.PersistentFlags().Bool("mir", false, "Output Mid-Level Intermediate Representation (MIR)")
 	compileCmd.PersistentFlags().Bool("air", false, "Output Arithmetic Intermediate Representation (AIR)")
 	compileCmd.PersistentFlags().Bool("stats", false, "Output summary statistics")
@@ -747,4 +786,6 @@ func init() {
 		"module ordering for --stats (name|total|complexity|lookups)")
 	// --order only affects the --stats output.
 	compileFlags.Require("order", "stats")
+	// --define only affects the binary output file.
+	compileFlags.Require("define", "output")
 }

--- a/pkg/cmd/zkc/debug.go
+++ b/pkg/cmd/zkc/debug.go
@@ -51,18 +51,15 @@ func runDebugCmd[F field.Element[F]](cmd *cobra.Command, args []string, field fi
 	//
 	input := ParseInputFile(args[0])
 	// Build artifacts (compiles source files or loads a prebuilt binary).
-	artifacts := Build[F](build, args[1:]...)
-	// Lower the bytecode program to a fixed-width form the bytecode interpreter
-	// can execute (mirroring the execute / trace commands).
-	program := vm.ProgramToProgram[vm.Uint, vm.Uint128](artifacts.ir)
+	_, binf := Build[F](build, args[1:]...)
 	// Filter out unnecessary inputs
-	input = vm.FilterInputs(program, input)
+	input = vm.FilterInputs(binf.RawProgram(), input)
 	// Construct a trace observer which prints each executed trace line, with
 	// register values rendered inline.
-	observer := NewDebugger(program)
+	observer := NewDebugger(binf.ExecutionProgram())
 	// Boot & execute via the bytecode interpreter, printing a trace line for
 	// each executed bytecode vector.
-	errs := vm.BootAndDebug(program, input, observer.Observe)
+	errs := vm.BootAndDebug(binf.ExecutionProgram(), input, observer.Observe)
 	//
 	if len(errs) > 0 {
 		for _, e := range errs {

--- a/pkg/cmd/zkc/execute.go
+++ b/pkg/cmd/zkc/execute.go
@@ -72,10 +72,9 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 		// resume mode: the input file holds a checkpoint (hex) to resume from,
 		// rather than an initial set of JSON inputs.  Execution then continues to
 		// completion via the fast bytecode interpreter.
-		resume   = GetFlag(cmd, "resume")
-		fastMode = build.config.IsFastMode()
+		resume = GetFlag(cmd, "resume")
 		// simple equivalence
-		tracing = !fastMode
+		tracing = !build.fastMode
 		//
 		trace   trace.Trace[F]
 		input   map[string][]byte
@@ -88,34 +87,30 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 	// Sanity permitted flag combinations
 	checkFlags(cmd, executeFlags)
 	// Build artifacts (compiles source files or loads a prebuilt binary).
-	artifacts := Build[F](build, args[1:]...)
-	// Translate bytecode => word machine
-	program := vm.ProgramToProgram[vm.Uint, vm.Uint128](artifacts.ir)
-	// Wrap the word machine in a binary file for execution / tracing / checking.
-	binfile := constraints.NewBinaryFile[F](nil, nil, field, build.config.GetMaxStaticHeight(), artifacts.ir)
+	_, binfile := Build[F](build, args[1:]...)
 	// =====================================================
 	// Trace / Execute
 	// =====================================================
 	if resume {
 		// Resume execution from the checkpoint held (in hex) in the input file,
 		// running the (unmodified) program to completion in fast mode.
-		outputs, errors = resumeFromCheckPoint(program, args[0])
+		outputs, errors = resumeFromCheckPoint(binfile.ExecutionProgram(), args[0])
 	} else {
 		// Parse an filter input file
-		input = vm.FilterInputs(program, ParseInputFile(args[0]))
+		input = vm.FilterInputs(binfile.RawProgram(), ParseInputFile(args[0]))
 		// decide what is happening
 		if checkpoint != "" {
 			// Checkpoint the function named in the spec (periodically with "f:N", or
 			// once with "f@N") and execute in fast mode, writing the resulting
 			// checkpoints to the output file (with -o) or to stdout otherwise.
-			outputs, errors = executeWithCheckPoint(program, checkpoint, outputFile, input)
+			outputs, errors = executeWithCheckPoint(binfile.ExecutionProgram(), checkpoint, outputFile, input)
 		} else if tracing {
 			outputs, _, trace, errors = binfile.Trace(input, traceConfig)
 		} else if build.gogen {
 			// Execute via native Go generated from the word machine.
-			outputs, errors = executeWithGogen(artifacts.ir, input)
+			outputs, errors = executeWithGogen(binfile.RawProgram(), input)
 		} else {
-			outputs, errors = binfile.Execute(input, 131072)
+			outputs, errors = binfile.Execute(input)
 		}
 	}
 	// =====================================================

--- a/pkg/cmd/zkc/generate.go
+++ b/pkg/cmd/zkc/generate.go
@@ -66,9 +66,9 @@ func runGenerateCmd[F field.Element[F]](cmd *cobra.Command, args []string, field
 	// Sanity permitted flag combinations
 	checkFlags(cmd, generateFlags)
 	// Build the word machine from the source files.
-	artifacts := Build[F](build, args...)
+	_, binfile := Build[F](build, args...)
 	// Translate bytecode => word machine
-	src, err := vm.GenerateGo(artifacts.ir, vm.GoGenConfig{
+	src, err := vm.GenerateGo(binfile.RawProgram(), vm.GoGenConfig{
 		Package: packageName(pkg),
 		Source:  sourceProvenance(args),
 	})

--- a/pkg/cmd/zkc/root.go
+++ b/pkg/cmd/zkc/root.go
@@ -16,10 +16,12 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"slices"
 
 	"github.com/LFDT-Lineth/zkc/pkg/ir"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/compiler/codegen"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -99,10 +101,14 @@ func GetBuildConfig[F field.Element[F]](cmd *cobra.Command, field field.Config) 
 	var (
 		build                 BuildConfig
 		fastMode              = GetFlag(cmd, "fast")
+		maxStaticHeight       = GetUint(cmd, "max-static-height")
 		verbosity             = GetVerboseLevel(cmd)
 		padding               = GetString(cmd, "padding")
 		strategy, strategy_ok = ir.GetPaddingStrategy(padding)
+		ignores               = GetStringArray(cmd, "ignore")
 	)
+	//
+	validateIgnores(ignores)
 	//
 	if !strategy_ok {
 		fmt.Printf("padding strategy %s unsupported\n", padding)
@@ -119,16 +125,18 @@ func GetBuildConfig[F field.Element[F]](cmd *cobra.Command, field field.Config) 
 	default:
 		log.SetLevel(log.WarnLevel)
 	}
+	// Configure fast mode
+	build.fastMode = fastMode
 	// Configure padding strategy
 	build.padding = strategy
 	// Configure go generator
 	build.gogen = GetFlag(cmd, "gogen")
+	// Configure ignored pipeline stages
+	build.ignores = ignores
 	// Configure compiler config
 	build.config = codegen.DEFAULT_CONFIG.
-		Inlining(GetFlag(cmd, "inline")).
-		FastMode(fastMode).
-		MaxStaticHeight(GetUint(cmd, "max-static-height")).
 		Field(field).
+		MaxStaticHeight(maxStaticHeight).
 		Verbose(verbosity >= VERBOSE_PRINTF)
 	//
 	return build
@@ -148,6 +156,15 @@ func findFieldAgnosticCmd(config field.Config, cmds []FieldAgnosticCmd) (cmd Fie
 	return cmd
 }
 
+func validateIgnores(ignores []string) {
+	for _, ignore := range ignores {
+		if !slices.Contains(vm.VALID_TRANSFORMS, ignore) {
+			fmt.Printf("unknown transform \"%s\"\n", ignore)
+			os.Exit(1)
+		}
+	}
+}
+
 func init() {
 	rootCmd.Flags().Bool("version", false, "Report version of this executable")
 	//
@@ -156,6 +173,7 @@ func init() {
 	rootCmd.PersistentFlags().CountP("verbose", "v",
 		"verbosity: default NONE; -v (INFO) info logging, -vv (DEBUG) machine execution steps, "+
 			"-vvv (PRINTF) additionally all printf output")
+	rootCmd.PersistentFlags().StringArrayP("ignore", "X", nil, "Ignore pipeline stage")
 	rootCmd.PersistentFlags().Bool("inline", true, "Apply inlining of #[inline] functions")
 	rootCmd.PersistentFlags().Bool("vectorize", true, "Apply instruction vectorization")
 	rootCmd.PersistentFlags().BoolP("gogen", "g", false, "enable Go code generation")

--- a/pkg/cmd/zkc/stats.go
+++ b/pkg/cmd/zkc/stats.go
@@ -148,7 +148,7 @@ func bucketCount(hist map[uint]uint, b bucket) uint {
 // constraint degrees are gathered from the pre-split bytecode program (ir) and
 // the post-split AIR schema respectively.  The order argument determines how the
 // modules are ordered (see orderModules).
-func PrintCompileStats[F field.Element[F]](air schema.AnySchema[F], ir vm.Program[vm.Uint], order string) {
+func PrintCompileStats[F field.Element[F], W vm.Word[W]](air schema.AnySchema[F], ir vm.Program[W], order string) {
 	var (
 		// Pre-split register histograms, keyed by module name.
 		preSplit = preSplitRegisters(ir)
@@ -247,7 +247,7 @@ type preSplitInfo struct {
 // preSplitRegisters builds, for each module in the bytecode program, its type
 // and a histogram mapping register bitwidth to the number of registers of that
 // width, plus a separate count of native (bitwidth-less) registers.
-func preSplitRegisters(ir vm.Program[vm.Uint]) map[string]preSplitInfo {
+func preSplitRegisters[W vm.Word[W]](ir vm.Program[W]) map[string]preSplitInfo {
 	var info = make(map[string]preSplitInfo)
 	//
 	for _, m := range ir.Modules() {
@@ -255,7 +255,7 @@ func preSplitRegisters(ir vm.Program[vm.Uint]) map[string]preSplitInfo {
 		// The maximum program-counter value is the number of bytecode lines (line
 		// indices plus the one-past-the-end halt value).  Only non-native
 		// functions carry a program counter.
-		if fn, ok := m.(*vm.Function[vm.Uint]); ok && !fn.IsNative() {
+		if fn, ok := m.(*vm.Function[W]); ok && !fn.IsNative() {
 			entry.pcMax = uint(len(fn.Vectors()))
 		}
 		//
@@ -276,15 +276,15 @@ func preSplitRegisters(ir vm.Program[vm.Uint]) map[string]preSplitInfo {
 // moduleType classifies a bytecode module: a "function" (possibly "native"), or
 // a memory by kind ("static", "ROM" read-only, "WOM" write-once, "RAM"
 // read-write).
-func moduleType(m vm.Module[vm.Uint]) string {
+func moduleType[W vm.Word[W]](m vm.Module[W]) string {
 	switch m := m.(type) {
-	case *vm.Function[vm.Uint]:
+	case *vm.Function[W]:
 		if m.IsNative() {
 			return "native"
 		}
 		//
 		return "function"
-	case *vm.Memory[vm.Uint]:
+	case *vm.Memory[W]:
 		switch {
 		case m.IsStatic():
 			return "static"

--- a/pkg/cmd/zkc/trace.go
+++ b/pkg/cmd/zkc/trace.go
@@ -85,16 +85,12 @@ func runTraceCmd[F field.Element[F]](cmd *cobra.Command, args []string, field fi
 		WithPadding(build.padding).
 		WithBatchSize(GetUint(cmd, "batch"))
 	// Build artifacts (compiles source files or loads a prebuilt binary).
-	artifacts := Build[F](build, args[1:]...)
-	// Translate bytecode => word machine
-	program := vm.ProgramToProgram[vm.Uint, vm.Uint128](artifacts.ir)
-	// Wrap the word machine in a binary file for tracing / checking.
-	binfile := constraints.NewBinaryFile[F](nil, nil, field, build.config.GetMaxStaticHeight(), artifacts.ir)
+	_, binfile := Build[F](build, args[1:]...)
 	// =====================================================
 	// Trace
 	// =====================================================
 	// Parse and filter input file
-	input := vm.FilterInputs(program, ParseInputFile(args[0]))
+	input := vm.FilterInputs(binfile.RawProgram(), ParseInputFile(args[0]))
 	// Always trace (no fast mode).  The raw (row-major) trace is retained for
 	// statistics, since it carries the original register/limb structure.
 	outputs, rtr, trace, errors := binfile.Trace(input, traceConfig)

--- a/pkg/test/util/check_valid.go
+++ b/pkg/test/util/check_valid.go
@@ -45,14 +45,12 @@ var (
 	DEFAULT_FIELDS = []field.Config{field.KOALABEAR_16}
 	// DEFAULT_CONFIG sets a default testing configuration
 	DEFAULT_CONFIG = Config{
-		fields:            DEFAULT_FIELDS,
-		constraints:       true,
-		splitting:         true,
-		fastModeSplitting: true,
-		gogen:             true,
-		verbose:           false,
-		sampling:          util.None[float64](),
-		maxStaticHeights:  []uint{codegen.DEFAULT_MAX_STATIC_HEIGHT},
+		fields:           DEFAULT_FIELDS,
+		constraints:      true,
+		gogen:            true,
+		verbose:          false,
+		sampling:         util.None[float64](),
+		maxStaticHeights: []uint{codegen.DEFAULT_MAX_STATIC_HEIGHT},
 		paddingStrategies: map[string]ir.PaddingStrategy{
 			"next-power-of-two-padding": ir.NextPowerOfTwoPadding,
 		}}
@@ -64,10 +62,6 @@ type Config struct {
 	fields []field.Config
 	// enable constraints checking, or not.
 	constraints bool
-	// enable register splitting
-	splitting bool
-	// enable register splitting in fast mode
-	fastModeSplitting bool
 	// enable the generated-Go ("native") executor
 	gogen bool
 	// enable verbose mode.
@@ -117,24 +111,9 @@ func (p Config) Constraints(flag bool) Config {
 	return p
 }
 
-// Splitting determines whether or not to apply register splitting when tracing.
-func (p Config) Splitting(flag bool) Config {
-	p.splitting = flag
-	//
-	return p
-}
-
 // Sampling sets the sampling ratio to use for the given constraint set.
 func (p Config) Sampling(ratio float64) Config {
 	p.sampling = util.Some(ratio)
-	//
-	return p
-}
-
-// FastModeSplitting determines whether or not to apply register splitting in
-// fast mode.
-func (p Config) FastModeSplitting(flag bool) Config {
-	p.fastModeSplitting = flag
 	//
 	return p
 }
@@ -154,6 +133,26 @@ func (p Config) Padding(strategies map[string]ir.PaddingStrategy) Config {
 	return p
 }
 
+// instantiate this configuration for (fast mode) execution.  Constraints are
+// never checked in fast mode, since the fast-mode pipeline does not generate
+// them.
+func (p Config) forExecution(build codegen.Config) testConfig {
+	return testConfig{p.Constraints(false), build, true}
+}
+
+// instantiate this configuration for tracing.
+func (p Config) forTracing(build codegen.Config) testConfig {
+	return testConfig{p, build, false}
+}
+
+type testConfig struct {
+	Config
+	// build config
+	build codegen.Config
+	//
+	fastMode bool
+}
+
 // CheckValid checks that a given source file compiles without any errors.
 // nolint
 func CheckValid(t *testing.T, test, ext string, config Config) {
@@ -167,17 +166,14 @@ func CheckValid(t *testing.T, test, ext string, config Config) {
 			testfile = fmt.Sprintf("%s.%s", test, ext)
 			// Setup default config
 			cfg = codegen.DEFAULT_CONFIG.
-				SplitRegisters(config.splitting).
-				Verbose(config.verbose).Field(f).
-				Word(DEFAULT_WORD)
+				Verbose(config.verbose).Field(f)
 		)
 		// Only run fast mode tests for the default height / padding, since
 		// neither static height nor padding impacts on fast mode.
 		t.Run(fmt.Sprintf("%s/fastmode", f.Name), func(t *testing.T) {
 			t.Parallel()
 			//
-			checkValidInternal(t, testfile, cfg.FastMode(true).SplitRegisters(config.fastModeSplitting),
-				config.Constraints(false), testcases[f])
+			checkValidInternal(t, testfile, config.forExecution(cfg), testcases[f])
 		})
 		// Run tracing tests across differing static heights to ensure resiliance
 		// against changing the default height.
@@ -186,29 +182,34 @@ func CheckValid(t *testing.T, test, ext string, config Config) {
 			t.Run(fmt.Sprintf("%s/height=%d", f.Name, height), func(t *testing.T) {
 				t.Parallel()
 				// Run all tests in tracing mode
-				checkValidInternal(t, testfile, cfg.MaxStaticHeight(height).FastMode(false), config, testcases[f])
+				checkValidInternal(t, testfile, config.forTracing(cfg.MaxStaticHeight(height)), testcases[f])
 			})
 		}
 	}
 }
 
-func checkValidInternal(t *testing.T, testfile string, cfg codegen.Config, config Config, testcases []TestCase) {
+func checkValidInternal(t *testing.T, testfile string, cfg testConfig, testcases []TestCase) {
 	var (
 		// Compile test program
-		p1 = compileTestProgram(t, testfile, cfg)
-		p2 = marshallUnmarshallMachine(p1, cfg.GetField())
+		p1 = compileTestProgram(t, testfile, cfg.build)
+		p2 = marshallUnmarshallMachine(p1, cfg.build.GetField())
 	)
 	// check for original machine
-	checkValidMachine(t, p1, cfg, config, testcases)
+	checkValidMachine(t, p1, cfg, testcases)
 	// check for marshalled / unmarshalled machine
-	checkValidMachine(t, p2, cfg, config, testcases)
+	checkValidMachine(t, p2, cfg, testcases)
 	// check gogen binaries (if requested)
-	if config.gogen {
+	if cfg.gogen {
 		checkValidGoGen(t, testfile, testcases, p1)
 	}
 }
 
-func checkValidGoGen(t *testing.T, testfile string, tests []TestCase, p vm.Program[vm.Uint]) {
+func checkValidGoGen(t *testing.T, testfile string, tests []TestCase, pU vm.Program[vm.Uint]) {
+	// Lower through the execution pipeline before handing to gogen.  GenerateGo
+	// requires Program[Uint] with registers no wider than 64 bits, so we split
+	// against a bounded word whilst staying in the Uint representation.
+	var p = vm.TransformForExecutionRaw[vm.Uint, vm.Uint](pU, vm.WORD_UINT128)
+	//
 	var binary, err = buildGogenProgram(t, p)
 	//
 	if errors.Is(err, errGoGenUnsupported) {
@@ -226,47 +227,48 @@ func checkValidGoGen(t *testing.T, testfile string, tests []TestCase, p vm.Progr
 	}
 }
 
-func checkValidMachine(t *testing.T, p vm.Program[vm.Uint], cfg codegen.Config, config Config, tests []TestCase) {
+func checkValidMachine(t *testing.T, p vm.Program[vm.Uint], cfg testConfig, tests []TestCase) {
 	// Run execution tests
 	for _, testcase := range tests {
 		runExecutionTests(t, p, testcase)
 	}
 	// Run checkpointing tests (if requested and in fastmode)
-	if config.checkpointing.HasValue() && cfg.IsFastMode() {
+	if cfg.checkpointing.HasValue() && cfg.fastMode {
 		for _, testcase := range tests {
-			runCheckpointTests(t, p, testcase, config.checkpointing.Unwrap())
+			runCheckpointTests(t, p, testcase, cfg.checkpointing.Unwrap())
 		}
 	}
 	// Run constraint tests
-	if config.constraints {
+	if cfg.constraints {
+		var field = cfg.build.GetField()
+		//
 		for _, test := range tests {
 			// Test all configured padding strategies
-			for name, strategy := range config.paddingStrategies {
+			for name, strategy := range cfg.paddingStrategies {
 				t.Run(name, func(t *testing.T) {
-					runConstraintTest(t, p, test, cfg, strategy)
+					runConstraintTest(t, p, test, field, strategy)
 				})
 			}
 		}
 	}
 }
 
-func runExecutionTests(t *testing.T, m vm.Program[vm.Uint], tc TestCase) {
+func runExecutionTests(t *testing.T, pU vm.Program[vm.Uint], tc TestCase) {
 	// Run the test
 	switch DEFAULT_WORD {
 	case vm.WORD_UINT64:
-		runFixedWidthExecutionTest[vm.Uint64](t, m, tc)
+		// Lower to fixed-width machine
+		pW := vm.TransformForExecution[vm.Uint, vm.Uint64](pU)
+		// Run execution test
+		runExecutionTest(t, pW, tc)
 	case vm.WORD_UINT128:
-		runFixedWidthExecutionTest[vm.Uint128](t, m, tc)
+		// Lower to fixed-width machine
+		pW := vm.TransformForExecution[vm.Uint, vm.Uint128](pU)
+		// Run execution test
+		runExecutionTest(t, pW, tc)
 	default:
 		panic(fmt.Sprintf("unknown machine word: %s", DEFAULT_WORD.Name))
 	}
-}
-
-func runFixedWidthExecutionTest[W vm.Word[W]](t *testing.T, pU vm.Program[vm.Uint], tc TestCase) {
-	// Lower to fixed-width machine
-	pW := vm.ProgramToProgram[vm.Uint, W](pU)
-	// Run execution test
-	runExecutionTest(t, pW, tc)
 }
 
 func runExecutionTest[W vm.Word[W]](t *testing.T, p vm.Program[W], test TestCase) {
@@ -313,13 +315,13 @@ func runCheckpointTests(t *testing.T, pU vm.Program[vm.Uint], tc TestCase, spec 
 	// Run the test
 	switch DEFAULT_WORD {
 	case vm.WORD_UINT64:
-		// Lower machine to use 64bit words
-		pW := vm.ProgramToProgram[vm.Uint, vm.Uint64](pU)
+		// Lower to fixed-width machine
+		pW := vm.TransformForExecution[vm.Uint, vm.Uint64](pU)
 		// Run test
 		runFixedWidthCheckpointTest(t, pW, tc, spec)
 	case vm.WORD_UINT128:
-		// Lower machine to use 128bit words
-		pW := vm.ProgramToProgram[vm.Uint, vm.Uint128](pU)
+		// Lower to fixed-width machine
+		pW := vm.TransformForExecution[vm.Uint, vm.Uint128](pU)
 		// Run test
 		runFixedWidthCheckpointTest(t, pW, tc, spec)
 	default:
@@ -415,19 +417,18 @@ func bootAndCheckpoint[W vm.Word[W]](t *testing.T, program vm.Program[W], tc Tes
 	return program, checkpoints, outputs
 }
 
-func runConstraintTest(t *testing.T, p vm.Program[vm.Uint], test TestCase, cfg codegen.Config,
+func runConstraintTest(t *testing.T, p vm.Program[vm.Uint], test TestCase, f field.Config,
 	paddingStrategy ir.PaddingStrategy) {
-	var f = cfg.GetField()
 	// Dispatch based on field config
 	switch f {
 	case field.GF_251:
-		testConstraintsWithField[gf251.Element](t, p, test, f, cfg.GetMaxStaticHeight(), paddingStrategy)
+		testConstraintsWithField[gf251.Element](t, p, test, paddingStrategy)
 	case field.GF_8209:
-		testConstraintsWithField[gf8209.Element](t, p, test, f, cfg.GetMaxStaticHeight(), paddingStrategy)
+		testConstraintsWithField[gf8209.Element](t, p, test, paddingStrategy)
 	case field.KOALABEAR_16:
-		testConstraintsWithField[koalabear.Element](t, p, test, f, cfg.GetMaxStaticHeight(), paddingStrategy)
+		testConstraintsWithField[koalabear.Element](t, p, test, paddingStrategy)
 	case field.BLS12_377:
-		//testConstraintsWithField[bls12_377.Element](t, p, test, f, cfg.GetMaxStaticHeight())
+		//testConstraintsWithField[bls12_377.Element](t, p, test, paddingStrategy)
 		panic("BLS12_377 not currently supported for tracing")
 	default:
 		panic(fmt.Sprintf("unknown field configuration: %s", f.Name))
@@ -435,11 +436,11 @@ func runConstraintTest(t *testing.T, p vm.Program[vm.Uint], test TestCase, cfg c
 }
 
 func testConstraintsWithField[F field.Element[F]](t *testing.T, p vm.Program[vm.Uint], test TestCase,
-	f field.Config, maxStaticHeight uint, paddingStrategy ir.PaddingStrategy) {
+	paddingStrategy ir.PaddingStrategy) {
 	//
 	var (
 		// construct binary file
-		binf = constraints.NewBinaryFile[F](nil, nil, f, maxStaticHeight, p)
+		binf = constraints.NewBinaryFile[F](nil, nil, p)
 		// decode inputs / outputs
 		inputs = vm.FilterInputs(p, test.data)
 		// trace configuration (optionally expanding each module up to the next

--- a/pkg/test/util/util.go
+++ b/pkg/test/util/util.go
@@ -175,21 +175,21 @@ func decodeInputsOutputs[W vm.Word[W]](t *testing.T, p vm.Program[W], data map[s
 func marshallUnmarshallMachine(m vm.Program[vm.Uint], f field.Config) vm.Program[vm.Uint] {
 	switch f {
 	case field.GF_251:
-		return roundTripMachine[gf251.Element](m, f)
+		return roundTripMachine[gf251.Element](m)
 	case field.GF_8209:
-		return roundTripMachine[gf8209.Element](m, f)
+		return roundTripMachine[gf8209.Element](m)
 	case field.KOALABEAR_16:
-		return roundTripMachine[koalabear.Element](m, f)
+		return roundTripMachine[koalabear.Element](m)
 	case field.BLS12_377:
-		return roundTripMachine[bls12_377.Element](m, f)
+		return roundTripMachine[bls12_377.Element](m)
 	default:
 		panic(fmt.Sprintf("unknown field configuration: %s", f.Name))
 	}
 }
 
-func roundTripMachine[F field.Element[F]](prog vm.Program[vm.Uint], f field.Config) vm.Program[vm.Uint] {
+func roundTripMachine[F field.Element[F]](prog vm.Program[vm.Uint]) vm.Program[vm.Uint] {
 	var (
-		original = constraints.NewBinaryFile[F](nil, nil, f, codegen.DEFAULT_MAX_STATIC_HEIGHT, prog)
+		original = constraints.NewBinaryFile[F](nil, nil, prog)
 		decoded  constraints.BinaryFile[F]
 	)
 	//
@@ -202,5 +202,5 @@ func roundTripMachine[F field.Element[F]](prog vm.Program[vm.Uint], f field.Conf
 		panic(fmt.Sprintf("unmarshalling machine failed: %s", err))
 	}
 	//
-	return decoded.Program()
+	return decoded.RawProgram()
 }

--- a/pkg/zkc/compiler/codegen/compile.go
+++ b/pkg/zkc/compiler/codegen/compile.go
@@ -94,7 +94,6 @@ func (p *Compiler) Compile(declarations []Declaration) (vm.Program[vm.Uint], []s
 		modules []vm.Module[vm.Uint]
 		mapping = make([]uint, len(declarations))
 		index   = uint(0)
-		inlines []string
 		errors  []source.SyntaxError
 	)
 	// Construct the mapping from ast declaration identifiers to vm module
@@ -145,10 +144,6 @@ func (p *Compiler) Compile(declarations []Declaration) (vm.Program[vm.Uint], []s
 			}
 			//
 			modules = append(modules, fn)
-			// Record functions to be inlined (see below).
-			if slices.Contains(c.Annotations(), "inline") {
-				inlines = append(inlines, c.Name())
-			}
 		case *decl.ResolvedInclude:
 			// ignore
 		case *decl.ResolvedMemory:
@@ -170,55 +165,7 @@ func (p *Compiler) Compile(declarations []Declaration) (vm.Program[vm.Uint], []s
 		return vm.Program[vm.Uint]{}, errors
 	}
 	// Construct bytecode program from descriptor modules.
-	program := vm.NewBytecodeProgram(p.config.field, modules...)
-	//
-	if p.config.inlining && len(inlines) > 0 {
-		// Apply function inlining
-		program = vm.InlineFunctions(program, inlines)
-	}
-
-	if p.config.fastMode {
-		// Apply transforms suitable for fast mode
-		program = vm.Vectorize(program)
-		// NOTE: eventually this will always be applied
-		if p.config.splitting {
-			// NOTE: in fast mode we split according to the target machine word,
-			// not the underlying field.
-			program = vm.SplitRegisters(p.config.word, program)
-		}
-	} else {
-		// Apply transformations required for tracing and constraint generation.
-		//
-		// Lower field casts (𝔽↔uint) first: the canonicality check for 𝔽→uint is
-		// emitted as a high-level "value < P" comparison
-		// It must therefore run before LowerComparisons
-		program = vm.LowerFieldCasts(program)
-		program = vm.LowerBitwise(program)
-		program = vm.LowerDivisions(program)
-		program = vm.LowerComparisons(program)
-		program = vm.Vectorize(program)
-		// Thread memory timestamps once the rows are final (after Vectorization).
-		program = vm.ThreadTimestamps(program)
-		program = vm.FactorSkipConditions(program)
-		program = vm.LowerSwitch(program)
-		// NOTE: eventually this will always be applied
-		if p.config.splitting {
-			program = vm.SplitRegisters(p.config.field, program)
-		}
-		// The following must be after splitting, but before range constraints:
-		program = vm.FactorLimbEqualities(program)
-		// Lower AND/OR/XOR after splitting
-		program = vm.LowerOrXorAnd(program, p.config.maxStaticHeight)
-		// Add tmp registers to hold lookup arguments (from calls and memread / write)
-		// when they are rewritten in the same vector (ex: x = f(x) or y = f(x); x = x + 1)
-		program = vm.FlattenLookupAccess(program)
-		//
-		program = vm.AddRangeConstraints(p.config.field, program, p.config.maxStaticHeight)
-	}
-	// Insert check casts to ensure appropriate safety checks during execution.
-	// TODO: this should be moved before AddRangeConstraints and consumed by it, so that
-	// range constraints are performed only for needed registers (instead of all registers).
-	program = vm.InsertCheckCasts(program)
+	program := vm.NewBytecodeProgram(p.config.field, p.config.maxStaticHeight, modules...)
 	// Validate program to catch any introduced corruption as early as possible.
 	if err := vm.ValidateProgram(program); err != nil {
 		panic(err)
@@ -297,17 +244,14 @@ func (p *Compiler) compileFunction(id uint, mapping []uint, program []Declaratio
 		field:       p.config.field,
 		srcmaps:     p.srcmaps,
 		verbose:     p.config.verbose,
-		fastMode:    p.config.fastMode,
 	}
 	//
 	for i, stmt := range fn.Code {
 		vectors[i] = compiler.compileStatement(uint(i), mapping, stmt)
 	}
-	//
-	kind := vm.BYTECODE_FUNCTION
-	if slices.Contains(fn.Annotations(), "native") {
-		kind = vm.NATIVE_FUNCTION
-	}
+	// Determine the appropriate function kind based on the given
+	// annotations.
+	kind := buildFunctionKind(fn)
 	// Record this function's declared memory effects, mapped from ast
 	// declaration indices to vm module ids, so the timestamp-threading transform
 	// can identify which functions access (and must thread a timestamp for) each
@@ -320,6 +264,26 @@ func (p *Compiler) compileFunction(id uint, mapping []uint, program []Declaratio
 	// Note: compiler.registers includes any temporaries allocated during
 	// statement compilation.
 	return vm.NewBytecodeFunction(fn.Name(), kind, compiler.registers, effects, vectors...), compiler.errors
+}
+
+// Build the appropriate function kind based on the given function annotations.
+func buildFunctionKind(fn *decl.ResolvedFunction) vm.FunctionKind {
+	var kind = vm.DEFAULT_FUNCTION
+	//
+	for _, ann := range fn.Annotations() {
+		switch ann {
+		case "inline":
+			kind = kind.WithInline(true)
+		case "native":
+			kind = kind.WithNative(true)
+		case "debug":
+			// ignore
+		default:
+			panic(fmt.Sprintf("unknown function annotation \"%s\"", ann))
+		}
+	}
+	//
+	return kind
 }
 
 // buildMemory constructs the memory descriptor module for a resolved memory

--- a/pkg/zkc/compiler/codegen/config.go
+++ b/pkg/zkc/compiler/codegen/config.go
@@ -12,7 +12,6 @@ package codegen
 
 import (
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
-	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm"
 )
 
 // DEFAULT_MAX_STATIC_HEIGHT is the default maximum height (i.e. number of rows) of
@@ -25,14 +24,9 @@ const DEFAULT_MAX_STATIC_HEIGHT uint = 65536
 // debugging, for example) should derive a custom Config via the chainable
 // setters below.
 var DEFAULT_CONFIG = Config{
-	field: field.KOALABEAR_16,
-	// NOTE: this should be deprecated to u64 at some point.
-	word:            vm.WORD_UINT128,
-	fastMode:        false,
-	inlining:        true,
-	verbose:         false,
-	splitting:       true,
+	field:           field.KOALABEAR_16,
 	maxStaticHeight: DEFAULT_MAX_STATIC_HEIGHT,
+	verbose:         false,
 }
 
 // Config captures the tunable aspects of the ZkC code generator.  Instances
@@ -44,24 +38,9 @@ type Config struct {
 	// a target field in order to correctly evaluate native expressions, and
 	// sanity check native initialisers, etc.
 	field field.Config
-	// word provides information about the target word.  That is, in fast mode,
-	// the machine word to be used for execution.  This must be larger than the
-	// field (for now).
-	word vm.WordConfig
-	// fastMode execution is useful to harvest partial trace information,
-	// such as memory access, module call, etc..., but can't be used
-	// to generate the trace witness nor to generate arithmetic constraints.
-	// It is defaulted to false.
-	fastMode bool
-	// inlining controls whether functions marked with the #[inline] annotation
-	// are inlined at their call sites (and removed).  This happens before
-	// native lowering and vectorisation.
-	inlining bool
 	// verbose controls whether printf statements are emitted as VM debug
 	// instructions during code generation, or skipped (the default).
 	verbose bool
-	// splitting controls whether or not register splitting is enabled.
-	splitting bool
 	// maxStaticHeight controls the maximum height (i.e. number of rows) of
 	// static tables. This is used to limit the size of static tables, as
 	// required by the prover. It defaults to 2^16.
@@ -70,20 +49,9 @@ type Config struct {
 
 // Field sets the target field configuration to use for this compiler.
 func (p Config) Field(field field.Config) Config {
-	var q = p
+	p.field = field
 	//
-	q.field = field
-	//
-	return q
-}
-
-// Word sets the target word configuration to use for this compiler.
-func (p Config) Word(word vm.WordConfig) Config {
-	var q = p
-	//
-	p.word = word
-	//
-	return q
+	return p
 }
 
 // GetField returns the specified field configuration.
@@ -105,47 +73,10 @@ func (p Config) GetMaxStaticHeight() uint {
 	return p.maxStaticHeight
 }
 
-// Inlining returns a copy of this Config in which function inlining is either
-// enabled (flag=true) or disabled (flag=false).  When enabled, functions
-// marked with the #[inline] annotation are inlined at their call sites.
-func (p Config) Inlining(flag bool) Config {
-	var q = p
-	//
-	q.inlining = flag
-	//
-	return q
-}
-
-// SplitRegisters returns a copy of this Config in which register splitting is
-// either enabled (flag=true) or disabled (flag=false).
-func (p Config) SplitRegisters(flag bool) Config {
-	var q = p
-	//
-	q.splitting = flag
-	//
-	return q
-}
-
-// FastMode returns a copy of this Config with fast-mode execution enabled (flag=true) or disabled (flag=false).
-func (p Config) FastMode(flag bool) Config {
-	var q = p
-	//
-	q.fastMode = flag
-	//
-	return q
-}
-
-// IsFastMode determines whether or not fast mode is enabled.
-func (p Config) IsFastMode() bool {
-	return p.fastMode
-}
-
 // Verbose returns a copy of this Config where printf statements are emitted
 // during code generation when flag=true, and skipped otherwise.
 func (p Config) Verbose(flag bool) Config {
-	var q = p
+	p.verbose = flag
 	//
-	q.verbose = flag
-	//
-	return q
+	return p
 }

--- a/pkg/zkc/compiler/codegen/statement.go
+++ b/pkg/zkc/compiler/codegen/statement.go
@@ -49,8 +49,6 @@ type StmtCompiler struct {
 	errors      []source.SyntaxError
 	// verbose retains printf output (suppressed by default)
 	verbose bool
-	// fastMode disables constraint-only rewrites not required by the vm.
-	fastMode bool
 }
 
 func (p *StmtCompiler) compileStatement(pc uint, mapping []uint, s Stmt) BytecodeVector {
@@ -72,17 +70,21 @@ func (p *StmtCompiler) compileStatement(pc uint, mapping []uint, s Stmt) Bytecod
 	case *stmt.Fail[symbol.Resolved]:
 		return p.compileFail(mapping, s.Chunks, s.Arguments)
 	case *stmt.Printf[symbol.Resolved]:
-		if !p.verbose {
-			return vm.NewBytecodeVector[vm.Uint]()
+		if p.verbose {
+			insns = p.compilePrintf(mapping, s.Chunks, s.Arguments)
 		}
-		//
-		return p.compilePrintf(mapping, s.Chunks, s.Arguments)
 	case *stmt.Return[symbol.Resolved]:
 		return vm.NewBytecodeVector(vm.Return[vm.Uint]())
 	default:
 		panic("unknown statement encountered")
 	}
-	//
+	// Ensure vector is terminated.  Only assignments and printfs reach this
+	// point, and neither ever ends in a Jmp / Ret / Fail, so the fall-through
+	// into the following statement must be made explicit (as Vectorize requires,
+	// and bytecode.Vector.Validate enforces).  Observe that pc+1 is always in
+	// bounds, since the final statement of a function is always a return.
+	insns = append(insns, vm.Jump[vm.Uint](vm.Address(pc+1)))
+	// Done
 	return vm.NewBytecodeVector(insns...)
 }
 
@@ -152,12 +154,10 @@ func (p *StmtCompiler) mapLVals(mapping []uint, lvals []LVal) ([][]vm.RegisterId
 }
 
 func (p *StmtCompiler) compilePrintf(mapping []uint, chunks []stmt.FormattedChunk, args []Expr,
-) BytecodeVector {
+) []Bytecode {
 	nchunks, sources, insns := p.compileFormattedChunks(mapping, chunks, args)
 	//
-	insns = append(insns, vm.Debug[vm.Uint](nchunks, sources))
-	//
-	return vm.NewBytecodeVector(insns...)
+	return append(insns, vm.Debug[vm.Uint](nchunks, sources))
 }
 
 func (p *StmtCompiler) compileFail(mapping []uint, chunks []stmt.FormattedChunk, args []Expr,

--- a/pkg/zkc/constraints/binary_file.go
+++ b/pkg/zkc/constraints/binary_file.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/LFDT-Lineth/zkc/pkg/ir"
 	"github.com/LFDT-Lineth/zkc/pkg/ir/air"
+	"github.com/LFDT-Lineth/zkc/pkg/ir/mir"
 	"github.com/LFDT-Lineth/zkc/pkg/rtrace"
 	"github.com/LFDT-Lineth/zkc/pkg/schema"
 	"github.com/LFDT-Lineth/zkc/pkg/schema/module"
@@ -53,6 +54,16 @@ var ZKC_EXEC [8]byte = [8]byte{'z', 'k', 'c', ' ', 'e', 'x', 'e', 'c'}
 // trace for those constraints from a given set of inputs.  Thus, we can write a
 // set of constraints to a binary file (e.g. on disk) which can then be read
 // back and used to generate a zero-knowledge proof.
+//
+// Only the raw program (along with the header and attributes) is serialised;
+// everything derived from it (the tracing / execution programs and the MIR /
+// AIR constraints) is compiled on demand and memoised in the caches below.
+//
+// NOTE: a BinaryFile is *not* safe for concurrent use.  Since the derived
+// artifacts are computed lazily, even apparently read-only methods (e.g.
+// AirConstraints, Check, Execute, Trace) mutate the caches.  Callers sharing a
+// BinaryFile across goroutines must therefore either provide their own
+// synchronisation, or force every artifact they need before handing it out.
 type BinaryFile[F field.Element[F]] struct {
 	// Header holds the magic identifier, version numbers, and optional JSON
 	// metadata for the file.
@@ -61,30 +72,63 @@ type BinaryFile[F field.Element[F]] struct {
 	// constraint checking but may be useful for tooling (e.g. source-column
 	// mappings for debug output).
 	attributes []Attribute
-	// Machine is the current representation of "constraints".  Its not very
-	// pretty, but right now its all we have.  This will certainly change in the
-	// near future.
+	// Program is the high-level representation of the "constraints".
 	program vm.Program[vm.Uint]
-	// cached fast machine
-	machineCache util.Option[*vm.Interpreter[vm.Uint128]]
+	// Ignores identifies pipeline stages which should be explicitly ignored
+	// when compiling downstream components (e.g. program for tracing, etc).
+	// Observe this is a property of how the artifacts below are compiled,
+	// rather than of the file itself, and is therefore not serialised.
+	ignores []string
+	// cache (fast mode) execution program
+	cachedExecutionProgram util.Option[vm.Program[vm.Uint128]]
+	// cache tracing program
+	cachedTracingProgram util.Option[vm.Program[vm.Uint32]]
+	// cached mir constraints
+	cachedMirConstraints util.Option[mir.Schema[F]]
 	// cached air constraints
-	constraintsCache util.Option[air.Schema[F]]
+	cachedAirConstraints util.Option[air.Schema[F]]
 }
 
-// NewBinaryFile constructs a BinaryFile with a header stamped at the current
-// major/minor version.  Metadata is an optional JSON blob stored verbatim in
-// the header (pass nil for none).  A field configuration is required to allow
-// clients to check they are targeting the expected field.
-func NewBinaryFile[F field.Element[F]](metadata []byte, attributes []Attribute, config field.Config,
-	maxStaticHeight uint, machine vm.Program[vm.Uint]) *BinaryFile[F] {
+// NewBinaryFile constructs a BinaryFile, for the given (raw) program, with a
+// header stamped at the current major/minor version.  Metadata is an optional
+// JSON blob stored verbatim in the header (pass nil for none), whilst
+// attributes carry supplementary information for tooling (again, pass nil for
+// none).  The field type parameter F determines the field against which the
+// program's field configuration is checked on deserialisation, and for which
+// constraints are subsequently generated.  No pipeline stages are ignored when
+// compiling the derived artifacts --- see WithIgnores for that.
+func NewBinaryFile[F field.Element[F]](metadata []byte, attributes []Attribute,
+	program vm.Program[vm.Uint]) *BinaryFile[F] {
 	//
 	return &BinaryFile[F]{
-		Header{ZKC_EXEC, BINFILE_MAJOR_VERSION, BINFILE_MINOR_VERSION, metadata},
-		attributes,
-		machine,
-		util.None[*vm.Interpreter[vm.Uint128]](),
-		util.None[air.Schema[F]](),
+		header:                 Header{ZKC_EXEC, BINFILE_MAJOR_VERSION, BINFILE_MINOR_VERSION, metadata},
+		attributes:             attributes,
+		program:                program,
+		ignores:                nil,
+		cachedExecutionProgram: util.None[vm.Program[vm.Uint128]](),
+		cachedTracingProgram:   util.None[vm.Program[vm.Uint32]](),
+		cachedMirConstraints:   util.None[mir.Schema[F]](),
+		cachedAirConstraints:   util.None[air.Schema[F]](),
 	}
+}
+
+// WithIgnores configures the set of pipeline stages to ignore when compiling
+// the artifacts derived from the raw program (i.e. the tracing / execution
+// programs and the MIR / AIR constraints).  Since this changes how those
+// artifacts are compiled, anything already cached against the previous set of
+// ignores is discarded.  This returns the receiver, allowing it to be chained
+// onto NewBinaryFile.
+func (p *BinaryFile[F]) WithIgnores(ignores ...string) *BinaryFile[F] {
+	p.ignores = ignores
+	// Discard artifacts compiled under the previous set of ignores.
+	p.clearCachedArtifacts()
+	//
+	return p
+}
+
+// Attributes returns the set of attributes embedded in this binary file.
+func (p *BinaryFile[F]) Attributes() []Attribute {
+	return p.attributes
 }
 
 // Header returns the binary file header, which contains the file version and
@@ -114,32 +158,115 @@ func (p *BinaryFile[F]) MaxStaticHeight() uint {
 	return p.program.MaxStaticHeight()
 }
 
-// AirConstraints returns the arithmetic (AIR) constraints encoded in this file.
-func (p *BinaryFile[F]) AirConstraints() air.Schema[F] {
-	// Check cache
-	if p.constraintsCache.HasValue() {
-		return p.constraintsCache.Unwrap()
-	}
-	//
-	var (
-		stats = util.NewPerfStats()
-		// Generate arithmetic intermediate representation
-		air = GenerateAirConstraints[vm.Uint, F](p.program, p.Field(), p.MaxStaticHeight())
-	)
-	// cache result
-	p.constraintsCache = util.Some(air)
-	// Log stats
-	stats.Log("Constraint compilation")
-	//
-	return air
-}
-
-// Program returns the bytecode program encoded in this file.
-func (p *BinaryFile[F]) Program() vm.Program[vm.Uint] {
+// RawProgram returns the raw bytecode program encoded in this file, which has
+// not been lowered or subject to register splitting.  As such, it is not a
+// suitable form for most use cases.
+func (p *BinaryFile[F]) RawProgram() vm.Program[vm.Uint] {
 	return p.program
 }
 
-// Check a given trace against the constraints embodied in this constraints
+// TracingProgram returns the program used for tracing.  This corresponds to the
+// raw program after lowering and register splitting as appropriate for tracing.
+// This will be constructed by compiling it from the raw program upon first
+// call, and subsequently cached.
+//
+// NOTE: this mutates the cache and is therefore not safe for concurrent use.
+func (p *BinaryFile[F]) TracingProgram() vm.Program[vm.Uint32] {
+	// Check cache
+	if !p.cachedTracingProgram.HasValue() {
+		var (
+			stats = util.NewPerfStats()
+			// Lower bytecode program
+			program = vm.TransformForTracing[vm.Uint, vm.Uint32](p.program, p.ignores...)
+		)
+		// Cache lowered program
+		p.cachedTracingProgram = util.Some(program)
+		// Log stats
+		stats.Log("Compiling tracing program")
+	}
+	//
+	return p.cachedTracingProgram.Unwrap()
+}
+
+// ExecutionProgram returns the program used for (fast mode) execution.  This
+// corresponds to the raw program after lowering and register splitting as
+// appropriate for fast-mode execution.  This will be constructed by compiling
+// it from the raw program upon first call, and subsequently cached.
+//
+// NOTE: this mutates the cache and is therefore not safe for concurrent use.
+func (p *BinaryFile[F]) ExecutionProgram() vm.Program[vm.Uint128] {
+	// Check cache
+	if !p.cachedExecutionProgram.HasValue() {
+		var (
+			stats = util.NewPerfStats()
+			// Lower bytecode program
+			program = vm.TransformForExecution[vm.Uint, vm.Uint128](p.program, p.ignores...)
+		)
+		// Cache lowered program
+		p.cachedExecutionProgram = util.Some(program)
+		// Log stats
+		stats.Log("Compiling (fast mode) execution program")
+	}
+	//
+	return p.cachedExecutionProgram.Unwrap()
+}
+
+// MirConstraints returns the mid-level (MIR) constraints generated from the
+// program encoded in this file. The constraints are constructed by compiling
+// them from the tracing program upon first call, and subsequently cached.
+// Observe that the MIR constraints should only be used for debugging purposes,
+// as they are not intended for sound constraint checking.
+//
+// NOTE: this mutates the cache and is therefore not safe for concurrent use.
+func (p *BinaryFile[F]) MirConstraints() mir.Schema[F] {
+	// Check cache
+	if !p.cachedMirConstraints.HasValue() {
+		var (
+			stats  = util.NewPerfStats()
+			tracer = p.TracingProgram()
+		)
+		// Generate + cache mid-level intermediate representation
+		p.cachedMirConstraints = util.Some(GenerateMirConstraints[vm.Uint32, F](tracer))
+		// Log stats
+		stats.Log("Compiling MIR constraints")
+	}
+	//
+	return p.cachedMirConstraints.Unwrap()
+}
+
+// AirConstraints returns the arithmetic (AIR) constraints encoded in this file.
+// The constraints are constructed by compiling them from the tracing program
+// upon first call, and subsequently cached.
+//
+// NOTE: this mutates the cache and is therefore not safe for concurrent use.
+func (p *BinaryFile[F]) AirConstraints() air.Schema[F] {
+	// Check cache
+	if !p.cachedAirConstraints.HasValue() {
+		var (
+			stats  = util.NewPerfStats()
+			tracer = p.TracingProgram()
+		)
+		// Generate + cache arithmetic intermediate representation
+		p.cachedAirConstraints = util.Some(GenerateAirConstraints[vm.Uint32, F](tracer))
+		// Log stats
+		stats.Log("Compiling AIR constraints")
+	}
+	//
+	return p.cachedAirConstraints.Unwrap()
+}
+
+// clearCachedArtifacts discards every artifact derived from the raw program,
+// such that each is recompiled on the next call to its accessor.  This is
+// necessary whenever something they were compiled against changes (i.e. the
+// program itself, or the set of ignored pipeline stages).
+func (p *BinaryFile[F]) clearCachedArtifacts() {
+	p.cachedExecutionProgram = util.None[vm.Program[vm.Uint128]]()
+	p.cachedTracingProgram = util.None[vm.Program[vm.Uint32]]()
+	p.cachedMirConstraints = util.None[mir.Schema[F]]()
+	p.cachedAirConstraints = util.None[air.Schema[F]]()
+}
+
+// Check a given trace against the AIR constraints embodied in this constraints
 // file, potentially producing one (or more) constraint failures.
 func (p *BinaryFile[F]) Check(tr trace.Trace[F], config TraceConfig) []schema.Failure {
 	var (
@@ -158,9 +285,12 @@ func (p *BinaryFile[F]) Check(tr trace.Trace[F], config TraceConfig) []schema.Fa
 // steps at a time, producing any outputs arising.  Execution is faster than
 // trace because it does not record any internal information about the trace ---
 // it simply extracts the outputs at the end.
-func (p *BinaryFile[F]) Execute(input map[string][]byte, n uint) (output map[string][]byte, errs []error) {
+func (p *BinaryFile[F]) Execute(input map[string][]byte) (output map[string][]byte, errs []error) {
+	var (
+		bci = vm.NewBytecodeInterpreter(p.ExecutionProgram())
+	)
 	// Boot and execute fast machine
-	output, _, errs = vm.BootAndExecute(p.cachedInterpreter(), input, n)
+	output, _, errs = vm.BootAndExecute(bci, input, math.MaxUint)
 	//
 	return output, errs
 }
@@ -179,7 +309,7 @@ func (p *BinaryFile[F]) Trace(input map[string][]byte, cfg TraceConfig,
 	var (
 		stats = util.NewPerfStats()
 		// Lower bytecode program
-		prog32 = vm.ProgramToProgram[vm.Uint, vm.Uint32](p.program)
+		prog32 = p.TracingProgram()
 		//
 		builder = tracer.NewBuilder[vm.Uint32, F, *rtrace.CompactModule[F]](prog32)
 	)
@@ -209,21 +339,6 @@ func (p *BinaryFile[F]) Trace(input map[string][]byte, cfg TraceConfig,
 	stats.Log("Trace generation")
 	//
 	return output, rtr, tr, errs
-}
-
-func (p *BinaryFile[F]) cachedInterpreter() *vm.Interpreter[vm.Uint128] {
-	var interpreter *vm.Interpreter[vm.Uint128]
-	//
-	if !p.machineCache.HasValue() {
-		// Lower bytecode program
-		bci := vm.ProgramToProgram[vm.Uint, vm.Uint128](p.program)
-		// Construct fresh interpreter
-		interpreter = vm.NewBytecodeInterpreter(bci)
-		// Compile bytecode interpreter
-		p.machineCache = util.Some(interpreter)
-	}
-	//
-	return interpreter
 }
 
 // ============================================================================
@@ -273,6 +388,13 @@ func (p *BinaryFile[F]) UnmarshalBinary(data []byte) error {
 		// Proceed to decoding any attributes.
 		if err = decoder.Decode(&p.attributes); err == nil {
 			if err = decoder.Decode(&p.program); err == nil {
+				// Discard the ignores configured against the previous program,
+				// since they are a property of how that program was to be
+				// compiled (see WithIgnores).
+				p.ignores = nil
+				// Discard anything cached against the previous program, since
+				// this file now describes a different one.
+				p.clearCachedArtifacts()
 				// extract modulus defined used for the compiling the given
 				// constraints.
 				var mod = p.program.Field().Modulus()

--- a/pkg/zkc/constraints/translator.go
+++ b/pkg/zkc/constraints/translator.go
@@ -35,8 +35,7 @@ import (
 // a corresponding set of MIR constraints.  The translation operates directly
 // over the bytecode program (its modules, registers and bytecode vectors),
 // without going through the legacy word / field machine.
-func GenerateMirConstraints[W vm.Word[W], F field.Element[F]](program vm.Program[W], field field.Config,
-	maxStaticHeight uint) mir.Schema[F] {
+func GenerateMirConstraints[W vm.Word[W], F field.Element[F]](program vm.Program[W]) mir.Schema[F] {
 	var (
 		infos   = program.Modules()
 		modules = make([]mir.Module[F], len(infos))
@@ -44,14 +43,14 @@ func GenerateMirConstraints[W vm.Word[W], F field.Element[F]](program vm.Program
 		// max static table size), i.e. floor(log2(maxStaticHeight)).
 		// It represents the maximum register width for which a static table can be use to range-check it.
 		// Wider registers require recursive range modules.
-		maxStaticWidth = uint(bits.Len(maxStaticHeight) - 1)
+		maxStaticWidth = uint(bits.Len(program.MaxStaticHeight()) - 1)
 		// Index the static range-check tables by width, so each register can be
 		// range-proved by a lookup into the matching $range_un table.
 		rangeTables = indexRangeTables[W, F](infos, maxStaticWidth)
 	)
 	//
 	for i, m := range infos {
-		modules[i] = translateModule[W, F](uint(i), m, infos, rangeTables, field, maxStaticWidth)
+		modules[i] = translateModule[W, F](uint(i), m, infos, rangeTables, program.Field(), maxStaticWidth)
 	}
 	//
 	return schema.NewUniformSchema(modules)
@@ -59,13 +58,12 @@ func GenerateMirConstraints[W vm.Word[W], F field.Element[F]](program vm.Program
 
 // GenerateAirConstraints is responsible for converting a bytecode program into
 // a corresponding set of AIR constraints.
-func GenerateAirConstraints[W vm.Word[W], F field.Element[F]](program vm.Program[W], field field.Config,
-	maxStaticHeight uint) air.Schema[F] {
+func GenerateAirConstraints[W vm.Word[W], F field.Element[F]](program vm.Program[W]) air.Schema[F] {
 	var (
-		mirc = GenerateMirConstraints[W, F](program, field, maxStaticHeight)
+		mirc = GenerateMirConstraints[W, F](program)
 	)
 	//
-	return mir.LowerToAir(mirc, field.BandWidth, mir.DEFAULT_OPTIMISATION_LEVEL)
+	return mir.LowerToAir(mirc, program.Field().BandWidth, mir.DEFAULT_OPTIMISATION_LEVEL)
 }
 
 func translateModule[W vm.Word[W], F field.Element[F]](ctx schema.ModuleId, m vm.Module[W],

--- a/pkg/zkc/vm/bytecode.go
+++ b/pkg/zkc/vm/bytecode.go
@@ -48,17 +48,8 @@ type Function[W Word[W]] = descriptor.Function[W]
 // native circuit and whether calls may supply undefined arguments.
 type FunctionKind = descriptor.FunctionKind
 
-// Function kinds, re-exported for use with NewBytecodeFunction.
-var (
-	// BYTECODE_FUNCTION is a safe function implemented by bytecode.
-	BYTECODE_FUNCTION = descriptor.BYTECODE_FUNCTION
-	// NATIVE_FUNCTION is a safe function backed by a native circuit.
-	NATIVE_FUNCTION = descriptor.NATIVE_FUNCTION
-	// UNSAFE_ARGS_FUNCTION is a bytecode function which may receive undefined arguments.
-	UNSAFE_ARGS_FUNCTION = descriptor.UNSAFE_ARGS_FUNCTION
-	// NATIVE_UNSAFE_ARGS_FUNCTION is a native function which may receive undefined arguments.
-	NATIVE_UNSAFE_ARGS_FUNCTION = descriptor.NATIVE_UNSAFE_ARGS_FUNCTION
-)
+// DEFAULT_FUNCTION is a safe function implemented by bytecode.
+var DEFAULT_FUNCTION = descriptor.BYTECODE_FUNCTION
 
 // Register describes a register
 type Register[W Word[W]] = descriptor.Register[W]
@@ -179,8 +170,18 @@ func ValidateProgram[W word.Word[W]](p Program[W]) error {
 
 // NewBytecodeProgram assembles a bytecode program directly from pre-lowered
 // descriptor modules, bypassing the word-machine round trip.
-func NewBytecodeProgram[W word.Word[W]](field field.Config, modules ...Module[W]) Program[W] {
-	return descriptor.NewProgram(field, modules...)
+//
+// NOTE: maxStaticHeight must be non-zero.  Downstream passes derive the maximum
+// static table width from it as floor(log2(maxStaticHeight)), computed as
+// bits.Len(maxStaticHeight)-1.  A zero height silently underflows that
+// expression to the maximum uint, whereupon every register width is treated as
+// statically enumerable and table generation exhausts memory.
+func NewBytecodeProgram[W word.Word[W]](field field.Config, maxStaticHeight uint, modules ...Module[W]) Program[W] {
+	if maxStaticHeight == 0 {
+		panic("invalid maximum static table height (zero)")
+	}
+	//
+	return descriptor.NewProgram(field, maxStaticHeight, modules...)
 }
 
 // NewBytecodeVector constructs a bytecode vector (single trace line) from the

--- a/pkg/zkc/vm/internal/descriptor/function_kind.go
+++ b/pkg/zkc/vm/internal/descriptor/function_kind.go
@@ -19,7 +19,7 @@ import (
 
 // FunctionKind captures the execution-relevant properties of a function.
 type FunctionKind struct {
-	native, unsafeArgs bool
+	native, unsafeArgs, inline bool
 }
 
 // IsNative reports whether this function is backed by a native circuit rather
@@ -28,10 +28,40 @@ func (p FunctionKind) IsNative() bool {
 	return p.native
 }
 
+// CanInline reports whether or not this function was marked as inlineable or
+// not.
+func (p FunctionKind) CanInline() bool {
+	return p.inline
+}
+
 // AllowsUnsafeArgs reports whether calls may supply arguments which are undefined
 // on some paths reaching the call.
 func (p FunctionKind) AllowsUnsafeArgs() bool {
 	return p.unsafeArgs
+}
+
+// WithInline updates this kind as to whether it was marked as inlineable or
+// not.
+func (p FunctionKind) WithInline(flag bool) FunctionKind {
+	p.inline = flag
+	//
+	return p
+}
+
+// WithNative updates this kind as to whether it represents a native function,
+// or not.
+func (p FunctionKind) WithNative(flag bool) FunctionKind {
+	p.native = flag
+	//
+	return p
+}
+
+// WithUnsafeArgs updates the specification as to whether this support unsafe
+// args, or not.
+func (p FunctionKind) WithUnsafeArgs(flag bool) FunctionKind {
+	p.unsafeArgs = flag
+	//
+	return p
 }
 
 // GobEncode marshals this function kind.
@@ -70,11 +100,5 @@ func (p *FunctionKind) GobDecode(data []byte) error {
 
 var (
 	// BYTECODE_FUNCTION represents a safe function implemented by bytecode.
-	BYTECODE_FUNCTION = FunctionKind{false, false}
-	// NATIVE_FUNCTION represents a safe function backed by a native circuit.
-	NATIVE_FUNCTION = FunctionKind{true, false}
-	// UNSAFE_ARGS_FUNCTION represents a bytecode function which may receive undefined arguments.
-	UNSAFE_ARGS_FUNCTION = FunctionKind{false, true}
-	// NATIVE_UNSAFE_ARGS_FUNCTION represents a native function which may receive undefined arguments.
-	NATIVE_UNSAFE_ARGS_FUNCTION = FunctionKind{true, true}
+	BYTECODE_FUNCTION = FunctionKind{false, false, false}
 )

--- a/pkg/zkc/vm/internal/descriptor/program.go
+++ b/pkg/zkc/vm/internal/descriptor/program.go
@@ -82,6 +82,8 @@ type Program[W word.Word[W]] struct {
 	modules []Module[W]
 	// field configuration for the target prime field
 	field field.Config
+	// maximum permitted height of static reference tables.
+	maxStaticHeight uint
 	// breakpoints records the set of instruction locations at which a breakpoint
 	// has been registered (see BreakPoint).  The compiler flags each such
 	// instruction with the BREAKPOINT modifier bit.
@@ -89,8 +91,9 @@ type Program[W word.Word[W]] struct {
 }
 
 // NewProgram creates a new program descriptor.
-func NewProgram[W word.Word[W]](field field.Config, modules ...Module[W]) Program[W] {
-	return Program[W]{modules, field, nil}
+func NewProgram[W word.Word[W]](field field.Config, maxStaticHeight uint, modules ...Module[W],
+) Program[W] {
+	return Program[W]{modules, field, maxStaticHeight, nil}
 }
 
 // BreakPoint returns a copy of this program in which a breakpoint has been
@@ -109,7 +112,7 @@ func (p Program[W]) BreakPoint(fid uint16, pc ProgramPoint) Program[W] {
 	//
 	breakpoints[BreakPointLabel{fid, pc}] = true
 	//
-	return Program[W]{p.modules, p.field, breakpoints}
+	return Program[W]{p.modules, p.field, p.maxStaticHeight, breakpoints}
 }
 
 // BreakPoints returns the set of instruction locations at which a breakpoint
@@ -142,15 +145,7 @@ func (p Program[W]) Field() field.Config {
 // MaxStaticHeight reports the maximum height (i.e. number of rows) of any static
 // table used within this program.
 func (p Program[W]) MaxStaticHeight() uint {
-	var depth = uint(0)
-	//
-	for _, m := range p.modules {
-		if ith, ok := m.(*Memory[W]); ok && ith.IsStatic() {
-			depth = max(depth, ith.StaticHeight())
-		}
-	}
-	//
-	return depth
+	return p.maxStaticHeight
 }
 
 // HasModule returns the identifier for the module with the given name, or returns
@@ -225,6 +220,11 @@ func (p *Program[W]) GobEncode() ([]byte, error) {
 	if err := gobEncoder.Encode(p.field); err != nil {
 		return nil, err
 	}
+	// Encode maximum static table height.  This must be carried in the file,
+	// since the range / bitwise tables generated downstream depend on it.
+	if err := gobEncoder.Encode(p.maxStaticHeight); err != nil {
+		return nil, err
+	}
 	// Each module, prefixed with a tag identifying its concrete type.
 	for _, m := range p.modules {
 		switch m := m.(type) {
@@ -265,6 +265,10 @@ func (p *Program[W]) GobDecode(data []byte) error {
 	}
 	// Decode field config
 	if err := gobDecoder.Decode(&p.field); err != nil {
+		return err
+	}
+	// Decode maximum static table height.
+	if err := gobDecoder.Decode(&p.maxStaticHeight); err != nil {
 		return err
 	}
 	//

--- a/pkg/zkc/vm/internal/gogen/field_test.go
+++ b/pkg/zkc/vm/internal/gogen/field_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/LFDT-Lineth/zkc/pkg/util"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/compiler/codegen"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm"
 )
 
@@ -94,9 +95,10 @@ func fieldTestProgram[W vm.Word[W]]() vm.Program[W] {
 
 	return vm.NewBytecodeProgram(
 		field.KOALABEAR_16,
+		codegen.DEFAULT_MAX_STATIC_HEIGHT,
 		vm.NewBytecodeMemory[W]("data", vm.PUBLIC_READ_ONLY_MEMORY, memRegs()),
 		vm.NewBytecodeMemory[W]("result", vm.PUBLIC_WRITE_ONCE_MEMORY, memRegs()),
-		vm.NewBytecodeFunction("main", vm.BYTECODE_FUNCTION, regs, nil, code),
+		vm.NewBytecodeFunction("main", vm.DEFAULT_FUNCTION, regs, nil, code),
 	)
 }
 

--- a/pkg/zkc/vm/internal/gogen/gen_test.go
+++ b/pkg/zkc/vm/internal/gogen/gen_test.go
@@ -460,7 +460,6 @@ func compileUintProgram(t testing.TB, program ast.Program, fastMode bool) vm.Pro
 	var (
 		cfg = codegen.DEFAULT_CONFIG.
 			Field(field.KOALABEAR_16).
-			FastMode(fastMode).
 			Verbose(false)
 		// compile into bytecode program
 		p, errs = ast.Compile(program, cfg)
@@ -468,9 +467,14 @@ func compileUintProgram(t testing.TB, program ast.Program, fastMode bool) vm.Pro
 	//
 	if len(errs) > 0 {
 		t.Fatalf("codegen: %v", errs)
+		return p
+	} else if fastMode {
+		// NOTE: the program stays in the Uint representation (GenerateGo
+		// requires it), but its registers are split against a bounded word.
+		return vm.TransformForExecutionRaw[vm.Uint, vm.Uint](p, vm.WORD_UINT128)
+	} else {
+		return vm.TransformForTracing[vm.Uint, vm.Uint](p)
 	}
-	//
-	return p
 }
 
 // shapes enumerates the two machine shapes every test runs against.

--- a/pkg/zkc/vm/internal/transform/check_casts.go
+++ b/pkg/zkc/vm/internal/transform/check_casts.go
@@ -45,7 +45,7 @@ func InsertCheckCasts[W word.Word[W]](program descriptor.Program[W]) descriptor.
 		}
 	}
 	//
-	return descriptor.NewProgram(program.Field(), out...)
+	return descriptor.NewProgram(program.Field(), program.MaxStaticHeight(), out...)
 }
 
 // insertFunctionCasts rewrites a single function's vectors, inserting cast checks

--- a/pkg/zkc/vm/internal/transform/factor_limb_equalities.go
+++ b/pkg/zkc/vm/internal/transform/factor_limb_equalities.go
@@ -75,7 +75,7 @@ func FactorLimbEqualities[W word.Word[W]](program descriptor.Program[W]) descrip
 		}
 	}
 
-	return descriptor.NewProgram(program.Field(), out...)
+	return descriptor.NewProgram(program.Field(), program.MaxStaticHeight(), out...)
 }
 
 func factorLimbEqualitiesFunction[W word.Word[W]](fn *descriptor.Function[W]) *descriptor.Function[W] {

--- a/pkg/zkc/vm/internal/transform/factor_skip_conditions.go
+++ b/pkg/zkc/vm/internal/transform/factor_skip_conditions.go
@@ -52,7 +52,7 @@ func FactorSkipConditions[W word.Word[W]](program descriptor.Program[W]) descrip
 		}
 	}
 
-	return descriptor.NewProgram(program.Field(), out...)
+	return descriptor.NewProgram(program.Field(), program.MaxStaticHeight(), out...)
 }
 
 func factorSkipConditionsFunction[W word.Word[W]](fn *descriptor.Function[W]) *descriptor.Function[W] {

--- a/pkg/zkc/vm/internal/transform/flatten_lookup_access.go
+++ b/pkg/zkc/vm/internal/transform/flatten_lookup_access.go
@@ -50,7 +50,7 @@ func FlattenLookupAccess[W word.Word[W]](program descriptor.Program[W]) descript
 		}
 	}
 
-	return descriptor.NewProgram(program.Field(), out...)
+	return descriptor.NewProgram(program.Field(), program.MaxStaticHeight(), out...)
 }
 
 func flattenLookupAccessFunction[W word.Word[W]](fn *descriptor.Function[W]) *descriptor.Function[W] {

--- a/pkg/zkc/vm/internal/transform/inline_functions.go
+++ b/pkg/zkc/vm/internal/transform/inline_functions.go
@@ -53,10 +53,10 @@ import (
 // vector containing a call at the call site.  It panics on: an unknown or
 // duplicate name; a native function; the entry function "main"; or (mutual)
 // recursion amongst the named functions.
-func InlineFunctions[W word.Word[W]](program descriptor.Program[W], names []string) descriptor.Program[W] {
+func InlineFunctions[W word.Word[W]](program descriptor.Program[W]) descriptor.Program[W] {
 	var (
 		modules = slices.Clone(program.Modules())
-		targets = resolveInlineTargets(modules, names)
+		targets = resolveInlineTargets(modules)
 	)
 	// Inline named functions in callee-first order.  At each step, pick a
 	// target whose body no longer calls any unprocessed target; hence, by the
@@ -78,34 +78,21 @@ func InlineFunctions[W word.Word[W]](program descriptor.Program[W], names []stri
 		remaining = slices.Delete(remaining, index, index+1)
 	}
 	// Remove now-dead targets, remapping module identifiers.
-	return descriptor.NewProgram(program.Field(), removeModules(modules, targets)...)
+	return descriptor.NewProgram(program.Field(),
+		program.MaxStaticHeight(), removeModules(modules, targets)...)
 }
 
 // resolveInlineTargets maps each name to its module identifier, sanity checking
 // that every name identifies a distinct function which can actually be inlined
 // (and removed).
-func resolveInlineTargets[W word.Word[W]](modules []descriptor.Module[W], names []string) []uint {
-	var targets = make([]uint, len(names))
-	//
-	for i, name := range names {
-		index := slices.IndexFunc(modules, func(m descriptor.Module[W]) bool { return m.Name() == name })
+func resolveInlineTargets[W word.Word[W]](modules []descriptor.Module[W]) []uint {
+	var targets []uint
+	// Find all inlineable targets
+	for i, mod := range modules {
 		//
-		switch {
-		case index < 0:
-			panic(fmt.Sprintf("cannot inline unknown function \"%s\"", name))
-		case name == "main":
-			panic("cannot inline entry function \"main\"")
-		case slices.Contains(targets[:i], uint(index)):
-			panic(fmt.Sprintf("duplicate inlined function \"%s\"", name))
+		if fun, ok := mod.(*descriptor.Function[W]); ok && fun.Kind().CanInline() {
+			targets = append(targets, uint(i))
 		}
-		//
-		if fn, ok := modules[index].(*descriptor.Function[W]); !ok {
-			panic(fmt.Sprintf("cannot inline non-function \"%s\"", name))
-		} else if fn.IsNative() {
-			panic(fmt.Sprintf("cannot inline native function \"%s\"", name))
-		}
-		//
-		targets[i] = uint(index)
 	}
 	//
 	return targets
@@ -220,21 +207,26 @@ func inlineCallSite[W word.Word[W]](code []BytecodeVector[W], pc, k uint, call *
 	// with the call's argument / return registers where possible (and
 	// allocating fresh shadows otherwise).
 	shadows := buildShadowMap(call, callee, alloc)
-	// Construct entry vector (argument copies)
-	vPre := buildEntryVector[W](codes[:k], shadows.entryCopies)
+	// Jumps amongst the codes preceding the call are remapped up front, rather
+	// than at the splice below, since the fall-through jump which
+	// buildEntryVector appends targets the inlined body and must not itself be
+	// remapped.
+	preCodes := remapJumps(bytecode.NewVector(codes[:k]...), pc, delta)
+	// Construct entry vector (argument copies), falling through into the body.
+	vPre := buildEntryVector[W](preCodes.Bytecodes, shadows.entryCopies, pc+1)
 	// Construct callee body
 	body := buildInlinedBody[W](callee, shadows.registers, pc+1, exitPC)
 	// Construct exit vector (output copies)
 	vPost := buildExitVector[W](codes[k+1:], shadows.exitCopies)
 	// Splice, remapping all jumps within original caller vectors (including
-	// v_pre / v_post, whose codes originate from vector pc).
+	// v_post, whose codes originate from vector pc).
 	ncode := make([]BytecodeVector[W], 0, uint(len(code))+delta)
 	//
 	for _, v := range code[:pc] {
 		ncode = append(ncode, remapJumps(v, pc, delta))
 	}
 	//
-	ncode = append(ncode, remapJumps(vPre, pc, delta))
+	ncode = append(ncode, vPre)
 	ncode = append(ncode, body...)
 	ncode = append(ncode, remapJumps(vPost, pc, delta))
 	//
@@ -413,19 +405,31 @@ func sameShape[W word.Word[W]](a, b descriptor.Register[W]) bool {
 
 // buildEntryVector constructs the vector replacing the front portion of the
 // vector enclosing the call site.  This retains all codes preceding the call,
-// followed by copies of the argument registers into the shadowed callee inputs.
+// followed by copies of the argument registers into the shadowed callee inputs,
+// and finally an explicit jump into the callee body (which begins at bodyPC).
 // Such copies enforce the same dynamic width checks as entering the callee's
 // stack frame did.
-func buildEntryVector[W word.Word[W]](codes []Bytecode[W], copies []registerCopy) BytecodeVector[W] {
+//
+// Making the fall-through into the body explicit keeps this vector
+// self-contained, as validation requires (see bytecode.Vector.Validate) and as
+// Vectorize assumes.  It also guarantees the vector is non-empty --- as it must
+// be in order to execute --- which matters when the call was the sole code of
+// its vector and no argument copies were needed.
+func buildEntryVector[W word.Word[W]](codes []Bytecode[W], copies []registerCopy,
+	bodyPC uint) BytecodeVector[W] {
+	//
 	var ncodes = slices.Clone(codes)
 	//
 	for _, c := range copies {
 		ncodes = append(ncodes, bytecode.Assign[W](c.target, c.source))
 	}
-	// Vectors must be non-empty in order to execute.
-	if len(ncodes) == 0 {
-		ncodes = append(ncodes, bytecode.NewSkip[W](0))
-	}
+	// Fall through into the callee body, which immediately follows.  Observe
+	// that appending here cannot disturb any skip within codes, since skip
+	// targets are relative to their own position.  Indeed, a skip targeting the
+	// call itself (which checkCallSite permits) lands on the first argument copy
+	// or, when there are none, on this jump --- either way, at the callee's
+	// entry.
+	ncodes = append(ncodes, bytecode.Jump[W](bytecode.Address(bodyPC)))
 	//
 	return bytecode.NewVector(ncodes...)
 }

--- a/pkg/zkc/vm/internal/transform/lower_bitwise.go
+++ b/pkg/zkc/vm/internal/transform/lower_bitwise.go
@@ -44,7 +44,10 @@ func LowerBitwise[W word.Word[W]](program descriptor.Program[W]) descriptor.Prog
 		}
 	}
 
-	return descriptor.NewProgram(program.Field(), append(out, helpers.modules()...)...)
+	return descriptor.NewProgram(
+		program.Field(),
+		program.MaxStaticHeight(),
+		append(out, helpers.modules()...)...)
 }
 
 // lowerBitwiseFunction rewrites each bytecode of a function via codeFn,

--- a/pkg/zkc/vm/internal/transform/lower_comparison.go
+++ b/pkg/zkc/vm/internal/transform/lower_comparison.go
@@ -36,7 +36,7 @@ func LowerComparisons[W word.Word[W]](program descriptor.Program[W]) descriptor.
 		}
 	}
 
-	return descriptor.NewProgram(program.Field(), out...)
+	return descriptor.NewProgram(program.Field(), program.MaxStaticHeight(), out...)
 }
 
 func lowerComparisonFunction[W word.Word[W]](fn *descriptor.Function[W]) *descriptor.Function[W] {

--- a/pkg/zkc/vm/internal/transform/lower_division.go
+++ b/pkg/zkc/vm/internal/transform/lower_division.go
@@ -43,7 +43,7 @@ func LowerDivisions[W word.Word[W]](program descriptor.Program[W]) descriptor.Pr
 		}
 	}
 
-	return descriptor.NewProgram(program.Field(), out...)
+	return descriptor.NewProgram(program.Field(), program.MaxStaticHeight(), out...)
 }
 
 func lowerDivisionFunction[W word.Word[W]](fn *descriptor.Function[W]) *descriptor.Function[W] {

--- a/pkg/zkc/vm/internal/transform/lower_field_cast.go
+++ b/pkg/zkc/vm/internal/transform/lower_field_cast.go
@@ -50,7 +50,7 @@ func LowerFieldCasts[W word.Word[W]](program descriptor.Program[W]) descriptor.P
 		}
 	}
 
-	return descriptor.NewProgram(program.Field(), append(modules, helpers.modules...)...)
+	return descriptor.NewProgram(program.Field(), program.MaxStaticHeight(), append(modules, helpers.modules...)...)
 }
 
 func lowerFieldCastFunction[W word.Word[W]](fn *descriptor.Function[W], helpers *fieldCastHelpers[W],

--- a/pkg/zkc/vm/internal/transform/lower_or_xor_and.go
+++ b/pkg/zkc/vm/internal/transform/lower_or_xor_and.go
@@ -37,12 +37,12 @@ import (
 //
 // It must run before AddRangeConstraints (so the freshly introduced registers
 // are range-checked) and the CALLs it introduces must subsequently be flattened.
-func LowerOrXorAnd[W word.Word[W]](program descriptor.Program[W], maxStaticHeight uint) descriptor.Program[W] {
+func LowerOrXorAnd[W word.Word[W]](program descriptor.Program[W]) descriptor.Program[W] {
 	var (
 		out = slices.Clone(program.Modules())
 		// maxStaticWidth is floor(log2(maxStaticHeight)); a bitwise table indexes
 		// two w-bit operands, so it fits only when 2w <= maxStaticWidth.
-		bitwiseStaticWidth = uint(bits.Len(maxStaticHeight)-1) / 2
+		bitwiseStaticWidth = uint(bits.Len(program.MaxStaticHeight())-1) / 2
 		helpers            = newBitwiseHelpers[W](uint(len(out)), bitwiseStaticWidth)
 	)
 
@@ -53,8 +53,9 @@ func LowerOrXorAnd[W word.Word[W]](program descriptor.Program[W], maxStaticHeigh
 			})
 		}
 	}
-
-	return descriptor.NewProgram(program.Field(), append(out, helpers.modules()...)...)
+	//
+	return descriptor.NewProgram(program.Field(),
+		program.MaxStaticHeight(), append(out, helpers.modules()...)...)
 }
 
 // bitwiseHelperKey identifies an AND/OR/XOR helper module.

--- a/pkg/zkc/vm/internal/transform/lower_switch.go
+++ b/pkg/zkc/vm/internal/transform/lower_switch.go
@@ -51,7 +51,7 @@ func LowerSwitch[W word.Word[W]](program descriptor.Program[W]) descriptor.Progr
 		}
 	}
 
-	return descriptor.NewProgram(program.Field(), out...)
+	return descriptor.NewProgram(program.Field(), program.MaxStaticHeight(), out...)
 }
 
 func lowerSwitchFunction[W word.Word[W]](fn *descriptor.Function[W]) *descriptor.Function[W] {

--- a/pkg/zkc/vm/internal/transform/program_to_program.go
+++ b/pkg/zkc/vm/internal/transform/program_to_program.go
@@ -49,7 +49,7 @@ func ProgramToProgram[W1 word.Word[W1], W2 word.Word[W2]](p descriptor.Program[W
 		modules[i] = lowering.lowerModule(m)
 	}
 	// Construct new program over W2
-	return descriptor.NewProgram(p.Field(), modules...)
+	return descriptor.NewProgram(p.Field(), p.MaxStaticHeight(), modules...)
 }
 
 type programToProgram[W1 word.Word[W1], W2 word.Word[W2]] struct {

--- a/pkg/zkc/vm/internal/transform/range_constraints.go
+++ b/pkg/zkc/vm/internal/transform/range_constraints.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/LFDT-Lineth/zkc/pkg/schema/register"
 	"github.com/LFDT-Lineth/zkc/pkg/util"
-	"github.com/LFDT-Lineth/zkc/pkg/util/field"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/bytecode"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/descriptor"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
@@ -49,17 +48,15 @@ const (
 // Native (field-element) registers are not ranged-checked.
 //
 // NOTE: this transform must run after register splitting.
-func AddRangeConstraints[W word.Word[W]](cfg field.Config, program descriptor.Program[W],
-	maxStaticHeight uint) descriptor.Program[W] {
+func AddRangeConstraints[W word.Word[W]](program descriptor.Program[W]) descriptor.Program[W] {
 	var (
 		modules = program.Modules()
 		// maxStaticWidth is the largest X for which 2^X <= maxStaticHeight (the
 		// max static table size), i.e. floor(log2(maxStaticHeigh)).
 		// It represents the maximum register width for which a static table can be use to range-check it.
 		// Wider registers require recursive range modules.
-		maxStaticWidth = uint(bits.Len(maxStaticHeight) - 1)
+		maxStaticWidth = uint(bits.Len(program.MaxStaticHeight()) - 1)
 	)
-
 	// First step, generate the range modules for every width which occurs on some register.
 	var extra = generateRangeModules(modules, maxStaticWidth)
 
@@ -67,7 +64,8 @@ func AddRangeConstraints[W word.Word[W]](cfg field.Config, program descriptor.Pr
 	modules = addRangeCalls(modules, extra, maxStaticWidth)
 
 	// Reassemble the program with the original modules plus the range modules.
-	return descriptor.NewProgram(program.Field(), append(slices.Clone(modules), extra...)...)
+	return descriptor.NewProgram(program.Field(),
+		program.MaxStaticHeight(), append(slices.Clone(modules), extra...)...)
 }
 
 func generateRangeModules[W word.Word[W]](modules []descriptor.Module[W],
@@ -282,7 +280,7 @@ func newRecursiveRangeModule[W word.Word[W]](name string, width uint, s rangeSpl
 	codes = appendRangeCheck(codes, hiID, s.hi, moduleOf, maxStaticWidth)
 	codes = append(codes, bytecode.NewRet[W]())
 	//
-	return descriptor.NewFunction(name, regs, descriptor.UNSAFE_ARGS_FUNCTION, nil,
+	return descriptor.NewFunction(name, regs, descriptor.BYTECODE_FUNCTION.WithUnsafeArgs(true), nil,
 		[]BytecodeVector[W]{bytecode.NewVector(codes...)})
 }
 

--- a/pkg/zkc/vm/internal/transform/split_registers.go
+++ b/pkg/zkc/vm/internal/transform/split_registers.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/LFDT-Lineth/zkc/pkg/util"
 	"github.com/LFDT-Lineth/zkc/pkg/util/collection/array"
+	"github.com/LFDT-Lineth/zkc/pkg/util/field"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/bytecode"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/descriptor"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/transform/split"
@@ -33,7 +34,7 @@ type RegisterId = descriptor.RegisterId
 // "r" of width u32. Subdividing this register into registers of at most 8bits
 // will result in four limbs: r'0, r'1, r'2 and r'3 where (by convention) r'0 is
 // the least significant.
-func SplitRegisters[W word.Word[W]](cfg word.Config, program descriptor.Program[W]) descriptor.Program[W] {
+func SplitRegisters[W word.Word[W]](target field.Config, program descriptor.Program[W]) descriptor.Program[W] {
 	var (
 		mods = program.Modules()
 		//
@@ -42,12 +43,12 @@ func SplitRegisters[W word.Word[W]](cfg word.Config, program descriptor.Program[
 	//
 	for i, ith := range mods {
 		// construct limbs map for this module
-		mapping := descriptor.NewLimbsMap(cfg, program.Field(), ith)
+		mapping := descriptor.NewLimbsMap(target, program.Field(), ith)
 		// split the module
 		out[i] = splitModule(mapping, mods, ith)
 	}
 	//
-	return descriptor.NewProgram(program.Field(), out...)
+	return descriptor.NewProgram(program.Field(), program.MaxStaticHeight(), out...)
 }
 
 func splitModule[W word.Word[W]](mapping descriptor.LimbsMap[W], mods []descriptor.Module[W],

--- a/pkg/zkc/vm/internal/transform/thread_timestamps.go
+++ b/pkg/zkc/vm/internal/transform/thread_timestamps.go
@@ -91,7 +91,7 @@ func ThreadTimestamps[W word.Word[W]](program descriptor.Program[W]) descriptor.
 		out[i] = threadFunction(mods, fn, effects)
 	}
 	//
-	return descriptor.NewProgram(program.Field(), out...)
+	return descriptor.NewProgram(program.Field(), program.MaxStaticHeight(), out...)
 }
 
 // stampState records, concretely, where the current timestamp of one memory

--- a/pkg/zkc/vm/internal/transform/vectorize.go
+++ b/pkg/zkc/vm/internal/transform/vectorize.go
@@ -72,6 +72,14 @@ import (
 //   - Back-edges.  A goto whose target would bring control back into the vector
 //     being built (a loop) is left alone; otherwise the inliner would unfold it
 //     indefinitely.
+//
+// PRECONDITION: every vector must terminate explicitly, in a Jmp / Ret / Fail.
+// Both the merge loop and the reachability walk driving it are expressed purely
+// in terms of Jmp bytecodes, so a vector relying on implicit fall-through would
+// appear to have no successor --- whereupon its successor is pruned as
+// unreachable.  Codegen establishes this invariant (see
+// codegen.compileStatement), every transform preceding this one preserves it,
+// and bytecode.Vector.Validate enforces it.
 func Vectorize[W word.Word[W]](program descriptor.Program[W]) descriptor.Program[W] {
 	modules := slices.Clone(program.Modules())
 	//
@@ -81,7 +89,7 @@ func Vectorize[W word.Word[W]](program descriptor.Program[W]) descriptor.Program
 		}
 	}
 	//
-	return descriptor.NewProgram(program.Field(), modules...)
+	return descriptor.NewProgram(program.Field(), program.MaxStaticHeight(), modules...)
 }
 
 // vectorizeFunction applies the per-function vectorisation pass, returning a new
@@ -95,10 +103,6 @@ func vectorizeFunction[W word.Word[W]](fn *descriptor.Function[W]) *descriptor.F
 	if n == 0 {
 		return fn
 	}
-	// Wrap every top-level vector and append a fall-through Jmp(pc+1) to those
-	// that don't already terminate.  This makes inter-vector control-flow explicit
-	// so that lastJump can drive the merge loop.
-	prepared := prepareCode[W](original)
 	//
 	var (
 		insns    = make([]BytecodeVector[W], n)
@@ -109,85 +113,18 @@ func vectorizeFunction[W word.Word[W]](fn *descriptor.Function[W]) *descriptor.F
 	visited[0] = true
 
 	worklist.Push(0)
-	// Vectorize bytecodes as much as possible.
+	// Vectorize bytecodes as much as possible.  Observe this relies on every
+	// vector terminating explicitly, since inter-vector control flow is
+	// discovered entirely through Jmp bytecodes (see Vectorize).
 	for !worklist.IsEmpty() {
 		pc := worklist.Pop()
-		insns[pc] = vectorizeInstruction[W](pc, prepared)
+		insns[pc] = vectorizeInstruction[W](pc, original)
 		markJumpTargets[W](insns[pc], visited, &worklist)
 	}
 	// Remove unreachable vectors and rebind jump targets.
 	insns = pruneUnreachableInstructions[W](insns)
 	//
 	return descriptor.NewFunction(fn.Name(), fn.Registers(), fn.Kind(), fn.Effects(), insns)
-}
-
-// prepareCode appends a fall-through Jmp(pc+1) to any vector that does not
-// already terminate (i.e. whose last code is not a Jmp / Ret / Fail).  Vectors
-// are built afresh so that subsequent merge work cannot accidentally mutate the
-// input function.
-func prepareCode[W word.Word[W]](code []BytecodeVector[W]) []BytecodeVector[W] {
-	var (
-		n        = uint(len(code))
-		prepared = make([]BytecodeVector[W], n)
-	)
-	//
-	for pc, vec := range code {
-		// Clone vector
-		codes := slices.Clone(vec.Bytecodes)
-		// Append fall-through Jmp if the vector doesn't already terminate.
-		if !endsInTerminator[W](codes) && uint(pc)+1 < n {
-			codes = append(codes, bytecode.Jump[W](bytecode.Address(uint(pc)+1)))
-		}
-		//
-		prepared[pc] = bytecode.NewVector(codes...)
-	}
-	//
-	return prepared
-}
-
-// endsInTerminator reports whether all paths through codes terminate without
-// falling off the end: the last code must be a Jmp/Ret/Fail, AND no
-// Skip/SkipIf/Switch anywhere in the vector has a skip target past the end (which
-// would create a second exit path not visible from the last bytecode).
-func endsInTerminator[W word.Word[W]](codes []Bytecode[W]) bool {
-	n := uint(len(codes))
-	//
-	if n == 0 {
-		return false
-	}
-	//
-	switch codes[n-1].(type) {
-	case *bytecode.Jmp[W], *bytecode.Ret[W], *bytecode.Fail[W]:
-	default:
-		return false
-	}
-	// Verify no skip-bytecode can reach past the end of the vector.
-	for i, code := range codes {
-		switch code := code.(type) {
-		case *bytecode.Skip[W]:
-			if uint(i)+uint(code.Skip)+1 >= n {
-				return false
-			}
-		case *bytecode.SkipIf[W]:
-			if uint(i)+uint(code.Skip)+1 >= n {
-				return false
-			}
-		case *bytecode.Switch[W]:
-			for _, dc := range code.Cases {
-				if uint(i)+uint(dc.Skip)+1 >= n {
-					return false
-				}
-			}
-		case *bytecode.Dispatch[W]:
-			for _, dc := range code.Cases {
-				if uint(i)+uint(dc.Skip)+1 >= n {
-					return false
-				}
-			}
-		}
-	}
-	//
-	return true
 }
 
 // vectorizeInstruction greedily absorbs the targets of jumps in the vector at pc
@@ -401,15 +338,40 @@ func pruneUnreachableInstructions[W word.Word[W]](insns []BytecodeVector[W]) []B
 		kept = append(kept, insn)
 	}
 	// Rebind every Jmp.Target to its new position.
-	for _, vec := range kept {
-		for i, code := range vec.Bytecodes {
-			if jmp, ok := code.(*bytecode.Jmp[W]); ok {
-				vec.Bytecodes[i] = bytecode.Jump[W](bytecode.Address(mapping[jmp.Target]))
-			}
-		}
+	for i, vec := range kept {
+		kept[i] = rebindJumps(vec, mapping)
 	}
 	//
 	return kept
+}
+
+// rebindJumps returns a vector in which every Jmp target has been remapped
+// through the given mapping.  Observe that the vector is rebuilt, rather than
+// updated in place, since a vector which the merge loop left untouched still
+// shares its bytecodes with the function being vectorised (see
+// vectorizeInstruction).  When no target actually moves, the vector is returned
+// as is --- which is the common case, since nothing moves unless something was
+// pruned.
+func rebindJumps[W word.Word[W]](vec BytecodeVector[W], mapping []uint) BytecodeVector[W] {
+	var (
+		ncodes  = make([]Bytecode[W], len(vec.Bytecodes))
+		changed = false
+	)
+	//
+	for i, code := range vec.Bytecodes {
+		if jmp, ok := code.(*bytecode.Jmp[W]); ok && uint(jmp.Target) != mapping[jmp.Target] {
+			ncodes[i] = bytecode.Jump[W](bytecode.Address(mapping[jmp.Target]))
+			changed = true
+		} else {
+			ncodes[i] = code
+		}
+	}
+	//
+	if !changed {
+		return vec
+	}
+	//
+	return bytecode.NewVector(ncodes...)
 }
 
 // validateConflicts reports the first read/write hazard found within vec, or nil

--- a/pkg/zkc/vm/internal/word/double.go
+++ b/pkg/zkc/vm/internal/word/double.go
@@ -28,8 +28,6 @@ type Double[W Word[W]] struct {
 	hi, lo W
 }
 
-var _ Word[Double[Uint64]] = Double[Uint64]{}
-
 // Add implementation for Word interface.
 func (p Double[W]) Add(w Double[W]) (Double[W], bool) {
 	lo, carry := p.lo.Add(w.lo)

--- a/pkg/zkc/vm/internal/word/uint.go
+++ b/pkg/zkc/vm/internal/word/uint.go
@@ -60,6 +60,11 @@ func (p Uint) AddMod(w, m Uint) Uint {
 	return Uint{res}
 }
 
+// Config implementation for Word interface.
+func (p Uint) Config() Config {
+	return WORD_UINT
+}
+
 // Bandwidth implementation for Word interface.
 func (p Uint) Bandwidth() uint {
 	return math.MaxUint

--- a/pkg/zkc/vm/internal/word/uint128.go
+++ b/pkg/zkc/vm/internal/word/uint128.go
@@ -97,6 +97,11 @@ func (p Uint128) BitLen() uint {
 	return uint(bits.Len64(p.hi)) + 64
 }
 
+// Config implementation for Word interface.
+func (p Uint128) Config() Config {
+	return WORD_UINT128
+}
+
 // Cmp implementation for Word interface.
 func (p Uint128) Cmp(o Uint128) int {
 	if c := cmp.Compare(p.hi, o.hi); c != 0 {

--- a/pkg/zkc/vm/internal/word/uint32.go
+++ b/pkg/zkc/vm/internal/word/uint32.go
@@ -72,6 +72,11 @@ func (p Uint32) BitLen() uint {
 	return uint(bits.Len32(p.value))
 }
 
+// Config implementation for Word interface.
+func (p Uint32) Config() Config {
+	return WORD_UINT32
+}
+
 // Cmp implementation for Word interface.
 func (p Uint32) Cmp(o Uint32) int {
 	return cmp.Compare(p.value, o.value)

--- a/pkg/zkc/vm/internal/word/uint64.go
+++ b/pkg/zkc/vm/internal/word/uint64.go
@@ -72,6 +72,11 @@ func (p Uint64) BitLen() uint {
 	return uint(bits.Len64(p.value))
 }
 
+// Config implementation for Word interface.
+func (p Uint64) Config() Config {
+	return WORD_UINT64
+}
+
 // Cmp implementation for Word interface.
 func (p Uint64) Cmp(o Uint64) int {
 	return cmp.Compare(p.value, o.value)

--- a/pkg/zkc/vm/internal/word/word.go
+++ b/pkg/zkc/vm/internal/word/word.go
@@ -13,6 +13,7 @@
 package word
 
 import (
+	"math"
 	"math/big"
 
 	"github.com/LFDT-Lineth/zkc/pkg/util"
@@ -22,6 +23,19 @@ import (
 
 // Config is (for now) simply an alias for field config.
 type Config = field.Config
+
+// WORD_UINT32 provides metadata about the Uint32 word type.
+var WORD_UINT32 = Config{Name: "Uint32", BandWidth: 32, RegisterWidth: 16}
+
+// WORD_UINT64 provides metadata about the Uint64 word type.
+var WORD_UINT64 = Config{Name: "Uint64", BandWidth: 64, RegisterWidth: 32}
+
+// WORD_UINT128 provides metadata about the Uint128 word type.
+var WORD_UINT128 = Config{Name: "Uint128", BandWidth: 128, RegisterWidth: 64}
+
+// WORD_UINT provides metadata about the Uint word type.  This word type should
+// not be used in practice for execution as it is highly inefficient.
+var WORD_UINT = Config{Name: "Uint", BandWidth: math.MaxUint, RegisterWidth: math.MaxUint}
 
 // Base captures the minimal set of requirements for a word used in the base
 // machine.
@@ -50,6 +64,8 @@ type Word[W any] interface {
 	AddMod(W, W) W
 	// Bitwise AND of two words.
 	And(W) W
+	// Returns the corresponding word configuration
+	Config() Config
 	// Returns the maximum number of bits of information a word this type can
 	// hold.
 	Bandwidth() uint

--- a/pkg/zkc/vm/transform.go
+++ b/pkg/zkc/vm/transform.go
@@ -13,10 +13,213 @@
 package vm
 
 import (
+	"fmt"
+	"slices"
+
+	"github.com/LFDT-Lineth/zkc/pkg/util/collection/array"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/transform"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
 )
+
+// TransformForExecution applies a transformation pipeline suitable for (fast
+// mode) execution, whilst ignoring any pipeline stages requested (i.e. for
+// debugging).  The target word W2 determines the size at which to split
+// registers.
+func TransformForExecution[W1 Word[W1], W2 Word[W2]](p Program[W1], ignores ...string) Program[W2] {
+	// Use target word to determine config
+	var targetWord W2
+	// Done
+	return TransformForExecutionRaw[W1, W2](p, targetWord.Config(), ignores...)
+}
+
+// TransformForExecutionRaw applies a transformation pipeline suitable for (fast
+// mode) execution, whilst ignoring any pipeline stages requested (i.e. for
+// debugging).  Here, the target word configuration determines the register
+// width to split against, which is distinct from the word type W2 the program
+// is finally concretized into.  Observe that W2 must be large enough to hold
+// all values of the target word, otherwise this will panic.
+func TransformForExecutionRaw[W1 Word[W1], W2 Word[W2]](p Program[W1], word WordConfig,
+	ignores ...string) Program[W2] {
+	//
+	var (
+		w2 W2
+		//
+		pipeline = NewTransformationPipeline("(fast mode) execution",
+			InlineFunctions[W1](),
+			Vectorize[W1](),
+			SplitRegisters[W1](word),
+			InsertCheckCasts[W1](),
+		)
+	)
+	// Sanity check
+	if word.BandWidth > w2.Bandwidth() {
+		panic(fmt.Sprintf("%s does not fit within u%d", word.Name, w2.Bandwidth()))
+	}
+	// ignore requested stages
+	pipeline = pipeline.Ignore(ignores...)
+	// Apply pipeline transformations
+	program := pipeline.Apply(p)
+	// Concretize the program
+	return transform.ProgramToProgram[W1, W2](program)
+}
+
+// TransformForTracing applies a transformation pipeline suitable for tracing,
+// whilst ignoring any pipeline stages requested (i.e. for debugging).
+func TransformForTracing[W1 Word[W1], W2 Word[W2]](p Program[W1], ignores ...string) Program[W2] {
+	var (
+		pipeline = NewTransformationPipeline("tracing",
+			InlineFunctions[W1](),
+			LowerFieldCasts[W1](),
+			LowerBitwise[W1](),
+			LowerDivisions[W1](),
+			LowerComparisons[W1](),
+			Vectorize[W1](),
+			ThreadTimestamps[W1](),
+			FactorSkipConditions[W1](),
+			LowerSwitch[W1](),
+			SplitRegisters[W1](p.Field()),
+			FactorLimbEqualities[W1](),
+			LowerOrXorAnd[W1](),
+			FlattenLookupAccess[W1](),
+			AddRangeConstraints[W1](),
+			InsertCheckCasts[W1](),
+		)
+	)
+	// ignore requested stages
+	pipeline = pipeline.Ignore(ignores...)
+	// Apply pipeline transformations
+	program := pipeline.Apply(p)
+	// Concretize the program
+	return transform.ProgramToProgram[W1, W2](program)
+}
+
+// Transform represents a single transformation in a transformation pipeline.
+// Every transform is uniquely identified by its name, and can specify other
+// transforms which must (or must not) run before it.
+type Transform[W Word[W]] struct {
+	// name of this transform
+	name string
+	// Precondition which must hold for this transformation to be valid.
+	precondition func(pipeline, transform string, i, n int, seen map[string]bool)
+	// Transforms is the function which actually implements the transformation.
+	transformer func(Program[W]) Program[W]
+}
+
+// TransformationPipeline represents single pipeline of transformations which
+// are applied in sequence to transform a program in one form into an equivalent
+// program in another form.  Example transformations would include register
+// splitting, register allocation, lowering divisions, etc.
+type TransformationPipeline[W Word[W]] struct {
+	name string
+	// config encapsulates necessary information for transforms
+	//config transform.Config
+	// transforms provides the list of transforms in the order they should be
+	// applied.
+	transforms []Transform[W]
+}
+
+// NewTransformationPipeline validates and constructs a new pipeline from a
+// given set of transforms.  This will panic if the dependency requirements are
+// not met.
+func NewTransformationPipeline[W Word[W]](name string, transforms ...Transform[W],
+) TransformationPipeline[W] {
+	// See holds those transforms seen in the pipeline so far.
+	var seen = make(map[string]bool)
+	//
+	for i, t := range transforms {
+		// Check precondition
+		t.precondition(name, t.name, i, len(transforms), seen)
+		// Mark transform as visited
+		seen[t.name] = true
+	}
+	// Done
+	return TransformationPipeline[W]{name, transforms}
+}
+
+// Ignore any requested pipeline stages
+func (p TransformationPipeline[W]) Ignore(ignores ...string) TransformationPipeline[W] {
+	for _, ignore := range ignores {
+		var (
+			pred = func(t Transform[W]) bool {
+				return t.name == ignore
+			}
+		)
+		//
+		if index := slices.IndexFunc(p.transforms, pred); index >= 0 {
+			p.transforms = array.RemoveAt(p.transforms, uint(index))
+		}
+	}
+	//
+	return p
+}
+
+// Apply this transformation pipeline to a given program, producing a
+// transformed (but otherwise equivalent) program.
+func (p TransformationPipeline[W]) Apply(program Program[W]) Program[W] {
+	// Apply each transformation in turn.
+	for _, t := range p.transforms {
+		program = t.transformer(program)
+	}
+	// Validate program to catch any introduced corruption as early as possible.
+	if err := ValidateProgram(program); err != nil {
+		panic(err)
+	}
+	//
+	return program
+}
+
+const (
+	// ADD_RANGE_CONSTRAINTS handle
+	ADD_RANGE_CONSTRAINTS = "add-range-constraints"
+	// FACTOR_LIMB_EQUALITIES handle
+	FACTOR_LIMB_EQUALITIES = "factor-limb-equalities"
+	// FACTOR_SKIP_CONDITIONS handle
+	FACTOR_SKIP_CONDITIONS = "factor-skip-conditions"
+	//FLATTERN_LOOKUP_ACCESSES handle
+	FLATTERN_LOOKUP_ACCESSES = "flattern-lookup-accesses"
+	// INLINE_FUNCTIONS handle
+	INLINE_FUNCTIONS = "inline-functions"
+	// INSERT_CHECKCASTS handle
+	INSERT_CHECKCASTS = "insert-checkcasts"
+	// LOWER_BITWISE handle
+	LOWER_BITWISE = "lower-bitwise"
+	// LOWER_COMPARISONS handle
+	LOWER_COMPARISONS = "lower-comparisons"
+	// LOWER_DIVISIONS handle
+	LOWER_DIVISIONS = "lower-divisions"
+	// LOWER_FIELDCASTS handle
+	LOWER_FIELDCASTS = "lower-fieldcasts"
+	// LOWER_ORXORAND handle
+	LOWER_ORXORAND = "lower-orxorand"
+	// LOWER_SWITCH handle
+	LOWER_SWITCH = "lower-switch"
+	// SPLIT_REGISTERS handle
+	SPLIT_REGISTERS = "split-registers"
+	// THREAD_TIMESTAMPS handle
+	THREAD_TIMESTAMPS = "thread-timestamps"
+	// VECTORIZE handle
+	VECTORIZE = "vectorize"
+)
+
+// VALID_TRANSFORMS contains the complete set of valid transform handles.
+var VALID_TRANSFORMS = []string{
+	ADD_RANGE_CONSTRAINTS,
+	FACTOR_LIMB_EQUALITIES,
+	FACTOR_SKIP_CONDITIONS,
+	FLATTERN_LOOKUP_ACCESSES,
+	INLINE_FUNCTIONS,
+	INSERT_CHECKCASTS,
+	LOWER_BITWISE,
+	LOWER_COMPARISONS,
+	LOWER_DIVISIONS,
+	LOWER_FIELDCASTS,
+	LOWER_ORXORAND,
+	LOWER_SWITCH,
+	SPLIT_REGISTERS,
+	THREAD_TIMESTAMPS,
+	VECTORIZE,
+}
 
 // LowerBitwise rewrites VM-level bitwise bytecodes into CALLs to helper
 // functions, returning the updated bytecode program (the helper function
@@ -24,8 +227,13 @@ import (
 //
 // NOTE: this transform must be applied BEFORE vectorization and register
 // splitting.
-func LowerBitwise[W word.Word[W]](program Program[W]) Program[W] {
-	return transform.LowerBitwise(program)
+func LowerBitwise[W word.Word[W]]() Transform[W] {
+	var (
+		transformer  = transform.LowerBitwise[W]
+		precondition = before(VECTORIZE, SPLIT_REGISTERS)
+	)
+	//
+	return Transform[W]{LOWER_BITWISE, precondition, transformer}
 }
 
 // LowerOrXorAnd rewrites bitwise AND/OR/XOR bytecodes into either a static-table
@@ -37,24 +245,34 @@ func LowerBitwise[W word.Word[W]](program Program[W]) Program[W] {
 //
 // NOTE: unlike LowerBitwise, this transform must be applied AFTER register
 // splitting and BEFORE range-constraint generation.
-func LowerOrXorAnd[W word.Word[W]](program Program[W], maxStaticHeight uint) Program[W] {
-	return transform.LowerOrXorAnd(program, maxStaticHeight)
+func LowerOrXorAnd[W word.Word[W]]() Transform[W] {
+	var (
+		transformer  = transform.LowerOrXorAnd[W]
+		precondition = and(after(SPLIT_REGISTERS), before("add-range-constraints"))
+	)
+	//
+	return Transform[W]{LOWER_ORXORAND, precondition, transformer}
 }
 
 // LowerComparisons rewrites SkipIf bytecodes with LT/GT/LTEQ/GTEQ conditions
 // into arithmetic-only sequences using biased subtraction and sign-bit extraction.
 // EQ and NEQ conditions are left unchanged.
-func LowerComparisons[W word.Word[W]](program Program[W]) Program[W] {
-	return transform.LowerComparisons(program)
+func LowerComparisons[W word.Word[W]]() Transform[W] {
+	var transformer = transform.LowerComparisons[W]
+	//
+	return Transform[W]{LOWER_COMPARISONS, noPrecondition, transformer}
 }
 
-// LowerFieldCasts inserts canonicality checks for extracting native field
-// values into uint registers. Uint-to-field casts reduce modulo P and need no
-// range check.
-// It must run after register splitting; the checks it generates come out
-// already comparison-lowered.
-func LowerFieldCasts[W word.Word[W]](program Program[W]) Program[W] {
-	return transform.LowerFieldCasts(program)
+// LowerFieldCasts (𝔽↔uint) first: the canonicality check for 𝔽→uint is
+// emitted as a high-level "value < P" comparison, which the comparison and
+// register-splitting passes below then turn into a subtract-with- borrow chain.
+// It must therefore run before LowerComparisons and SplitRegisters.
+func LowerFieldCasts[W word.Word[W]]() Transform[W] {
+	var (
+		transformer = transform.LowerFieldCasts[W]
+	)
+	//
+	return Transform[W]{LOWER_FIELDCASTS, noPrecondition, transformer}
 }
 
 // LowerDivisions rewrites INT_DIV and INT_REM bytecodes into a non-deterministic
@@ -69,8 +287,12 @@ func LowerFieldCasts[W word.Word[W]](program Program[W]) Program[W] {
 // decompiled into a word machine.
 //
 // NOTE: This pass must run before LowerComparisons.
-func LowerDivisions[W word.Word[W]](program Program[W]) Program[W] {
-	return transform.LowerDivisions(program)
+func LowerDivisions[W word.Word[W]]() Transform[W] {
+	var (
+		transformer = transform.LowerDivisions[W]
+	)
+	//
+	return Transform[W]{LOWER_DIVISIONS, noPrecondition, transformer}
 }
 
 // LowerSwitch rewrites Switch (multiway skip) bytecodes into equivalent
@@ -83,8 +305,13 @@ func LowerDivisions[W word.Word[W]](program Program[W]) Program[W] {
 //
 // NOTE: this transform must run before register splitting (which does not
 // support Switch bytecodes).
-func LowerSwitch[W word.Word[W]](program Program[W]) Program[W] {
-	return transform.LowerSwitch(program)
+func LowerSwitch[W word.Word[W]]() Transform[W] {
+	var (
+		transformer  = transform.LowerSwitch[W]
+		precondition = before(SPLIT_REGISTERS)
+	)
+	//
+	return Transform[W]{LOWER_SWITCH, precondition, transformer}
 }
 
 // ThreadTimestamps threads a per-memory timestamp through every function which
@@ -96,14 +323,23 @@ func LowerSwitch[W word.Word[W]](program Program[W]) Program[W] {
 // vectorisation — so a vector is genuinely one trace row and the canonical
 // stamp register is written at most once per executed path through it — and
 // before register splitting.
-func ThreadTimestamps[W word.Word[W]](program Program[W]) Program[W] {
-	return transform.ThreadTimestamps(program)
+func ThreadTimestamps[W word.Word[W]]() Transform[W] {
+	var (
+		transformer  = transform.ThreadTimestamps[W]
+		precondition = before(SPLIT_REGISTERS)
+	)
+	//
+	return Transform[W]{THREAD_TIMESTAMPS, precondition, transformer}
 }
 
 // Vectorize merges as many bytecodes as possible into each (vector / trace-line)
 // bytecode, subject to register-conflict (data hazard) constraints.
-func Vectorize[W word.Word[W]](program Program[W]) Program[W] {
-	return transform.Vectorize(program)
+func Vectorize[W word.Word[W]]() Transform[W] {
+	var (
+		transformer = transform.Vectorize[W]
+	)
+	//
+	return Transform[W]{VECTORIZE, noPrecondition, transformer}
 }
 
 // FlattenLookupAccess introduces a tmp register to hold a call (or memory access) argument
@@ -114,8 +350,13 @@ func Vectorize[W word.Word[W]](program Program[W]) Program[W] {
 // so that the call can be rewritten as:
 // 1. tmp = x; x = f(tmp)
 // 2. tmp = x; y = f(tmp); x = x + 1
-func FlattenLookupAccess[W word.Word[W]](program Program[W]) Program[W] {
-	return transform.FlattenLookupAccess(program)
+func FlattenLookupAccess[W word.Word[W]]() Transform[W] {
+	var (
+		transformer  = transform.FlattenLookupAccess[W]
+		precondition = after(SPLIT_REGISTERS)
+	)
+	//
+	return Transform[W]{FLATTERN_LOOKUP_ACCESSES, precondition, transformer}
 }
 
 // FactorSkipConditions rewrites equality SkipIf bytecodes (EQ/NEQ) so that the
@@ -124,8 +365,13 @@ func FlattenLookupAccess[W word.Word[W]](program Program[W]) Program[W] {
 //
 // NOTE: This transform must run after vectorisation and before register
 // splitting.
-func FactorSkipConditions[W word.Word[W]](program Program[W]) Program[W] {
-	return transform.FactorSkipConditions(program)
+func FactorSkipConditions[W word.Word[W]]() Transform[W] {
+	var (
+		transformer  = transform.FactorSkipConditions[W]
+		precondition = and(after(VECTORIZE), before(SPLIT_REGISTERS))
+	)
+	//
+	return Transform[W]{FACTOR_SKIP_CONDITIONS, precondition, transformer}
 }
 
 // FactorLimbEqualities rewrites equality SkipIf bytecodes (EQ/NEQ) comparing
@@ -136,8 +382,13 @@ func FactorSkipConditions[W word.Word[W]](program Program[W]) Program[W] {
 //
 // NOTE: This transform must run after register splitting and before range
 // constraints are added.
-func FactorLimbEqualities[W word.Word[W]](program Program[W]) Program[W] {
-	return transform.FactorLimbEqualities(program)
+func FactorLimbEqualities[W word.Word[W]]() Transform[W] {
+	var (
+		transformer  = transform.FactorLimbEqualities[W]
+		precondition = and(after(SPLIT_REGISTERS), before("add-range-constraints"))
+	)
+	//
+	return Transform[W]{FACTOR_LIMB_EQUALITIES, precondition, transformer}
 }
 
 // InlineFunctions returns an equivalent bytecode program in which every call to
@@ -152,8 +403,13 @@ func FactorLimbEqualities[W word.Word[W]](program Program[W]) Program[W] {
 //
 // NOTE: This transform must be applied before vectorisation, since it splits
 // the vector enclosing a call at the call site.
-func InlineFunctions[W word.Word[W]](program Program[W], names []string) Program[W] {
-	return transform.InlineFunctions(program, names)
+func InlineFunctions[W word.Word[W]]() Transform[W] {
+	var (
+		transformer  = transform.InlineFunctions[W]
+		precondition = before(VECTORIZE)
+	)
+	//
+	return Transform[W]{INLINE_FUNCTIONS, precondition, transformer}
 }
 
 // SplitRegisters all modules to meet a given bandwidth and maximum register width.
@@ -162,34 +418,25 @@ func InlineFunctions[W word.Word[W]](program Program[W], names []string) Program
 // width). For example, consider a register "r" of width u32. Subdividing this
 // register into registers of at most 8bits will result in four limbs: r'0, r'1,
 // r'2 and r'3 where (by convention) r'0 is the least significant.
-func SplitRegisters[W word.Word[W]](cfg WordConfig, program Program[W]) Program[W] {
-	return transform.SplitRegisters(cfg, program)
+func SplitRegisters[W word.Word[W]](field field.Config) Transform[W] {
+	var (
+		transformer = func(p Program[W]) Program[W] {
+			return transform.SplitRegisters[W](field, p)
+		}
+	)
+	//
+	return Transform[W]{SPLIT_REGISTERS, noPrecondition, transformer}
 }
 
 // AddRangeConstraints adds a range-proof constraint for each register in the program.
 // This is done by adding lookups from each (non-constant) register to a precomputed
 // table of all valid values for that register width.
-func AddRangeConstraints[W word.Word[W]](cfg field.Config, program Program[W], maxStaticHeight uint) Program[W] {
-	return transform.AddRangeConstraints(cfg, program, maxStaticHeight)
-}
-
-// ProgramToProgram transforms a bytecode program operating over a given word
-// type (W1) into an identical program which operates over a different word type
-// (W2).  Generally speaking, we are going from a larger word (e.g. word.Uint) to
-// a smaller word (e.g. word.Uint64).  This is the program-level analogue of
-// WordToWordMachine.
-//
-// The transformation is purely structural: bytecodes are re-typed but not
-// rewritten or lowered, register declarations are preserved verbatim (no
-// splitting or width changes), and constants are not reduced modulo the field.
-// Static memory contents are converted element-wise; non-static memories carry
-// no contents in either representation.
-//
-// This function will panic if it encounters a register, constant or memory cell
-// which exceeds the bandwidth of W2.  Callers needing to target a narrower word
-// size than some source register widths should run SplitRegisters first.
-func ProgramToProgram[W1 word.Word[W1], W2 word.Word[W2]](p Program[W1]) Program[W2] {
-	return transform.ProgramToProgram[W1, W2](p)
+func AddRangeConstraints[W word.Word[W]]() Transform[W] {
+	var (
+		transformer = transform.AddRangeConstraints[W]
+	)
+	//
+	return Transform[W]{ADD_RANGE_CONSTRAINTS, noPrecondition, transformer}
 }
 
 // InsertCheckCasts inserts the width-check (CHECKCAST) bytecodes required by a
@@ -197,6 +444,51 @@ func ProgramToProgram[W1 word.Word[W1], W2 word.Word[W2]](p Program[W1]) Program
 // without casts; this pass adds the cast checks each operation needs (resolving
 // call / memory references against the program's module signatures) and rewrites
 // branch offsets accordingly.  It must run on a complete program.
-func InsertCheckCasts[W word.Word[W]](program Program[W]) Program[W] {
-	return transform.InsertCheckCasts(program)
+func InsertCheckCasts[W word.Word[W]]() Transform[W] {
+	var (
+		transformer = transform.InsertCheckCasts[W]
+	)
+	//
+	return Transform[W]{INSERT_CHECKCASTS, last, transformer}
+}
+
+func after(deps ...string) func(string, string, int, int, map[string]bool) {
+	return func(pipeline, name string, _ int, _ int, seen map[string]bool) {
+		for _, dep := range deps {
+			if _, ok := seen[dep]; !ok {
+				panic(
+					fmt.Sprintf("transformation \"%s\" must run after \"%s\" in pipeline \"%s\"", name, dep, pipeline))
+			}
+		}
+	}
+}
+
+func before(deps ...string) func(string, string, int, int, map[string]bool) {
+	return func(pipeline, name string, _ int, _ int, seen map[string]bool) {
+		for _, dep := range deps {
+			if _, ok := seen[dep]; ok {
+				panic(
+					fmt.Sprintf("transformation \"%s\" must run before \"%s\" in pipeline \"%s\"", name, dep, pipeline))
+			}
+		}
+	}
+}
+
+func and(conds ...func(string, string, int, int, map[string]bool)) func(string, string, int, int, map[string]bool) {
+	return func(pipeline, name string, i int, n int, seen map[string]bool) {
+		for _, c := range conds {
+			c(pipeline, name, i, n, seen)
+		}
+	}
+}
+
+func noPrecondition(_, _ string, _, _ int, _ map[string]bool) {
+	// do nothing
+}
+
+func last(name, pipeline string, i, n int, _ map[string]bool) {
+	if i+1 != n {
+		panic(
+			fmt.Sprintf("transformation \"%s\" must run last in pipeline \"%s\"", name, pipeline))
+	}
 }

--- a/pkg/zkc/vm/word.go
+++ b/pkg/zkc/vm/word.go
@@ -13,6 +13,7 @@
 package vm
 
 import (
+	"math"
 	"math/big"
 
 	"github.com/LFDT-Lineth/zkc/pkg/util/collection/array"
@@ -33,6 +34,10 @@ var WORD_UINT64 = WordConfig{Name: "Uint64", BandWidth: 64, RegisterWidth: 32}
 
 // WORD_UINT128 provides metadata about the Uint128 word type.
 var WORD_UINT128 = WordConfig{Name: "Uint128", BandWidth: 128, RegisterWidth: 64}
+
+// WORD_UINT provides metadata about the Uint word type.  This word type should
+// not be used in practice for execution as it is highly inefficient.
+var WORD_UINT = WordConfig{Name: "Uint", BandWidth: math.MaxUint, RegisterWidth: math.MaxUint}
 
 // Word abstracts the data type (a.k.a the "machine word") used for holding
 // values within the machine.  The reason for abstracting this concept is to


### PR DESCRIPTION
This refactors the build system to use a "transformation pipeline" as a new fundamental primitive.  There are two key pipelines: one for (fast mode) execution; and another for tracing.  Pipelines allow more explicit encoding of dependency requirements between transforms, amongst other things.