### PR TITLE
feat: optimise lookup constraint checking

### DIFF
--- a/pkg/cmd/corset/check.go
+++ b/pkg/cmd/corset/check.go
@@ -248,7 +248,7 @@ func CheckTrace[F field.Element[F]](ir string, schema sc.AnySchema[F], tf lt.Tra
 	//
 	stats = util.NewPerfStats()
 	// Check constraints
-	if errs := sc.Accepts(builder.Parallelism(), builder.BatchSize(), schema, trace); len(errs) > 0 {
+	if errs := sc.Accepts(builder.Parallelism(), schema, trace); len(errs) > 0 {
 		ReportFailures(ir, errs, trace, builder.Mapping(), cfg)
 		return false
 	}

--- a/pkg/cmd/zkc/trace.go
+++ b/pkg/cmd/zkc/trace.go
@@ -83,7 +83,8 @@ func runTraceCmd[F field.Element[F]](cmd *cobra.Command, args []string, field fi
 	// Configure tracing
 	traceConfig := constraints.DEFAULT_TRACE_CONFIG.
 		WithPadding(build.padding).
-		WithBatchSize(GetUint(cmd, "batch"))
+		WithBatchSize(GetUint(cmd, "batch")).
+		WithParallelism(!GetFlag(cmd, "sequential"))
 	// Build artifacts (compiles source files or loads a prebuilt binary).
 	_, binfile := Build[F](build, args[1:]...)
 	// =====================================================
@@ -149,6 +150,7 @@ func init() {
 	traceCmd.Flags().StringP("output", "o", "", "specify output file for writing trace")
 	traceCmd.Flags().BoolP("check", "c", false, "check generated trace against constraints")
 	traceCmd.Flags().Bool("stats", false, "show overall stats for the generated trace")
+	traceCmd.Flags().Bool("sequential", false, "force sequential tracing")
 	traceCmd.Flags().BoolP("inspect", "i", false, "open the generated trace in the interactive inspector")
 	traceCmd.PersistentFlags().UintP("batch", "b", 1024, "specify batch size for constraint checking")
 }

--- a/pkg/ir/air/constraint.go
+++ b/pkg/ir/air/constraint.go
@@ -21,7 +21,6 @@ import (
 	"github.com/LFDT-Lineth/zkc/pkg/schema/register"
 	"github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/util"
-	"github.com/LFDT-Lineth/zkc/pkg/util/collection/bit"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
 	"github.com/LFDT-Lineth/zkc/pkg/util/source/sexp"
 )
@@ -84,9 +83,8 @@ func (p Air[F, C]) Air() {
 // Accepts determines whether a given constraint accepts a given trace or
 // not.  If not, a failure is produced.  Otherwise, a bitset indicating
 // branch coverage is returned.
-func (p Air[F, C]) Accepts(trace trace.Trace[F], schema schema.AnySchema[F],
-) (bit.Set, schema.Failure) {
-	return p.constraint.Accepts(trace, schema)
+func (p Air[F, C]) Accepts(trace trace.Trace[F], schema schema.AnySchema[F], ctx schema.Context[F]) schema.Failure {
+	return p.constraint.Accepts(trace, schema, ctx)
 }
 
 // Bounds determines the well-definedness bounds for this constraint in both the
@@ -128,6 +126,11 @@ func (p Air[F, C]) Consistent(schema schema.AnySchema[F]) []error {
 // context).
 func (p Air[F, C]) Contexts() []schema.ModuleId {
 	return p.constraint.Contexts()
+}
+
+// Sets implementation for schema.Constraint interface.
+func (p Air[F, C]) Sets() []schema.SetId {
+	return p.constraint.Sets()
 }
 
 // Name returns a unique name and case number for a given constraint.  This

--- a/pkg/ir/builder/expansion.go
+++ b/pkg/ir/builder/expansion.go
@@ -81,10 +81,8 @@ func SequentialTraceExpansion[F field.Element[F]](schema sc.AnySchema[F], trace 
 func ParallelTraceExpansion[F field.Element[F]](batchsize uint, schema sc.AnySchema[F], trace *tr.ArrayTrace[F]) error {
 	var (
 		batchNum = 0
-		// Construct a communication channel for errors.
-		ch = make(chan columnBatch[F], batchsize)
 		//
-		expander = NewExpander[F](schema.Width(), schema.Assignments())
+		expander = NewExpander(schema.Width(), schema.Assignments())
 	)
 	// Iterate until all assignments processed.
 	for !expander.Done() {
@@ -92,22 +90,18 @@ func ParallelTraceExpansion[F field.Element[F]](batchsize uint, schema sc.AnySch
 			stats = util.NewPerfStats()
 			batch = expander.Next(batchsize)
 		)
-		// Dispatch next batch of assignments.
-		dispatchReadyAssignments(batch, schema, trace, ch)
-		//
-		batches := make([]columnBatch[F], len(batch))
-		// Collect all the results
-		for i := range len(batch) {
-			batches[i] = <-ch
-			// Read from channel
-			if batches[i].err != nil {
+		// Process all assignments in this wave in parallel using a worker pool.
+		results := util.ParallelMap(batch, func(_ uint, ith sc.Assignment[F]) columnBatch[F] {
+			cols, err := ith.Compute(trace, schema)
+			return columnBatch[F]{ith.RegistersWritten(), cols, err}
+		})
+		// Check for errors and fill computed columns into the trace.
+		for _, r := range results {
+			if r.err != nil {
 				// Fail immediately
-				return batches[i].err
+				return r.err
 			}
-		}
-		// Once we get here, all go rountines are complete and we are sequential
-		// again.
-		for _, r := range batches {
+			//
 			fillComputedColumns(r.targets, r.columns, trace)
 		}
 		// Log stats about this batch
@@ -117,21 +111,6 @@ func ParallelTraceExpansion[F field.Element[F]](batchsize uint, schema sc.AnySch
 	}
 	// Done
 	return nil
-}
-
-// Dispatch the given set of assignments with results being fed back into the
-// shared channel.
-func dispatchReadyAssignments[F field.Element[F]](batch []sc.Assignment[F], schema sc.AnySchema[F],
-	trace *tr.ArrayTrace[F], ch chan columnBatch[F]) {
-	// Dispatch each assignment in the batch
-	for _, ith := range batch {
-		// Dispatch!
-		go func(targets []register.Ref) {
-			cols, err := ith.Compute(trace, schema)
-			// Send outcome back
-			ch <- columnBatch[F]{targets, cols, err}
-		}(ith.RegistersWritten())
-	}
 }
 
 // Fill a set of columns with their computed results.  The column index is that

--- a/pkg/ir/builder/lowering.go
+++ b/pkg/ir/builder/lowering.go
@@ -68,37 +68,43 @@ func sequentialLowering[F field.Element[F]](ltf lt.TraceFile) (array.Builder[F],
 func parallelLowering[F field.Element[F]](ltf lt.TraceFile) (array.Builder[F], []lt.Module[F]) {
 	//
 	var (
-		ncols = lt.NumberOfColumns(ltf.RawModules())
-		//
-		loweredModules []lt.Module[F] = make([]lt.Module[F], ltf.Width())
 		// Construct new pool
 		builder = array.NewStaticBuilder[F]()
-		// Construct a communication channel split columns.
-		c = make(chan result[F], ncols)
+		// Collect all (module, column) pairs into a flat slice.
+		jobs = make([]loweringJob, 0, lt.NumberOfColumns(ltf.RawModules()))
 	)
-	// Split column concurrently
+	// Build the job list: one job per column across all modules.
 	for i := range ltf.Width() {
 		var ith = ltf.Module(i)
-		// Construct enough blank columns
-		loweredModules[i] = lt.NewModule(ith.Name(), make([]lt.Column[F], ith.Width()))
-		// Dispatch go-routines to fill them
 		for j := range ith.Width() {
-			var jth = ith.Column(j)
-			go func(mid uint, cid uint, column tr.Column[word.BigEndian]) {
-				// Send outcome back
-				c <- result[F]{mid, cid, lowerRawColumn(column, builder)}
-			}(i, j, jth)
+			jobs = append(jobs, loweringJob{i, j, ith.Column(j)})
 		}
 	}
-	// Collect results
-	for range ncols {
-		// Read from channel
-		res := <-c
-		// Assign split
+	// Lower all columns in parallel using a worker pool.
+	results := util.ParallelMap(jobs, func(_ uint, job loweringJob) result[F] {
+		return result[F]{job.module, job.col, lowerRawColumn(job.rawCol, builder)}
+	})
+	// Construct lowered modules with enough blank columns.
+	loweredModules := make([]lt.Module[F], ltf.Width())
+	//
+	for i := range ltf.Width() {
+		var ith = ltf.Module(i)
+		//
+		loweredModules[i] = lt.NewModule(ith.Name(), make([]lt.Column[F], ith.Width()))
+	}
+	// Assign lowered columns into their modules.
+	for _, res := range results {
 		loweredModules[res.module].Columns[res.column] = res.data
 	}
 	// Done
 	return builder, loweredModules
+}
+
+// loweringJob represents a single column to be lowered within a module.
+type loweringJob struct {
+	module uint
+	col    uint
+	rawCol tr.Column[word.BigEndian]
 }
 
 type result[F any] struct {

--- a/pkg/ir/builder/splitting.go
+++ b/pkg/ir/builder/splitting.go
@@ -85,46 +85,50 @@ func parallelTraceSplitting[F field.Element[F]](ltf lt.TraceFile, mapping module
 	[]lt.Module[F], []error) {
 	//
 	var (
-		ncols = lt.NumberOfColumns(ltf.RawModules())
-		//
-		splits = make([][][]lt.Column[F], ltf.Width())
 		// Allocate fresh array builder
 		builder = array.NewStaticBuilder[F]()
-		// Construct a communication channel split columns.
-		c = make(chan splitResult[F], ncols)
-		//
-		errors []error
+		// Collect all (module, column) pairs into a flat slice.
+		jobs = make([]splittingJob[F], 0, lt.NumberOfColumns(ltf.RawModules()))
 	)
-	// Split column concurrently
+	// Build the job list: one job per column across all modules.
 	for i := range ltf.Width() {
-		var (
-			ith = ltf.Module(i)
-			// Access mapping for enclosing module
-			modmap = mapping.ModuleOf(ith.Name())
-		)
-		// Initiali split array
-		splits[i] = make([][]lt.Column[F], ith.Width())
+		var ith = ltf.Module(i)
+		// Access mapping for enclosing module
+		var modmap = mapping.ModuleOf(ith.Name())
 		//
 		for j := range ith.Width() {
-			var jth = ith.Column(j)
-			// Start go-routine for this column
-			go func(mid, cid uint, column tr.Column[word.BigEndian], mapping module.LimbsMap) {
-				// Send outcome back
-				data, errors := splitRawColumn(column, builder, modmap)
-				c <- splitResult[F]{mid, cid, data, errors}
-			}(i, j, jth, mapping)
+			jobs = append(jobs, splittingJob[F]{i, j, ith.Column(j), modmap})
 		}
 	}
-	// Collect results
-	for range ncols {
-		// Read from channel
-		res := <-c
-		// Assign split
+	// Split all columns in parallel using a worker pool.
+	results := util.ParallelMap(jobs, func(_ uint, job splittingJob[F]) splitResult[F] {
+		data, errors := splitRawColumn(job.rawCol, builder, job.modmap)
+		return splitResult[F]{job.module, job.col, data, errors}
+	})
+	// Organise results into a per-module split structure.
+	var (
+		splits = make([][][]lt.Column[F], ltf.Width())
+		errors []error
+	)
+	//
+	for i := range ltf.Width() {
+		splits[i] = make([][]lt.Column[F], ltf.Module(i).Width())
+	}
+	//
+	for _, res := range results {
 		splits[res.module][res.column] = res.data
 		errors = append(errors, res.errors...)
 	}
 	// Flatten split
 	return builder, flatten(ltf, splits), errors
+}
+
+// splittingJob represents a single column to be split within a module.
+type splittingJob[F any] struct {
+	module uint
+	col    uint
+	rawCol tr.Column[word.BigEndian]
+	modmap register.LimbsMap
 }
 
 func flatten[W any](tf lt.TraceFile, splits [][][]lt.Column[W]) []lt.Module[W] {

--- a/pkg/ir/mir/constraint.go
+++ b/pkg/ir/mir/constraint.go
@@ -20,7 +20,6 @@ import (
 	"github.com/LFDT-Lineth/zkc/pkg/schema/register"
 	"github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/util"
-	"github.com/LFDT-Lineth/zkc/pkg/util/collection/bit"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
 	"github.com/LFDT-Lineth/zkc/pkg/util/source/sexp"
 )
@@ -57,10 +56,9 @@ func NewRangeConstraint[F field.Element[F]](handle string, ctx schema.ModuleId, 
 // Accepts determines whether a given constraint accepts a given trace or
 // not.  If not, a failure is produced.  Otherwise, a bitset indicating
 // branch coverage is returned.
-func (p Constraint[F]) Accepts(trace trace.Trace[F],
-	schema schema.AnySchema[F]) (bit.Set, schema.Failure) {
+func (p Constraint[F]) Accepts(trace trace.Trace[F], sc schema.AnySchema[F], ctx schema.Context[F]) schema.Failure {
 	//
-	return p.constraint.Accepts(trace, schema)
+	return p.constraint.Accepts(trace, sc, ctx)
 }
 
 // Bounds determines the well-definedness bounds for this constraint in both the
@@ -91,6 +89,11 @@ func (p Constraint[F]) Complexity() uint {
 // context).
 func (p Constraint[F]) Contexts() []schema.ModuleId {
 	return p.constraint.Contexts()
+}
+
+// Sets implementation for schema.Constraint interface.
+func (p Constraint[F]) Sets() []schema.SetId {
+	return p.constraint.Sets()
 }
 
 // Name returns a unique name and case number for a given constraint.  This

--- a/pkg/schema/constraint.go
+++ b/pkg/schema/constraint.go
@@ -13,9 +13,16 @@
 package schema
 
 import (
+	"cmp"
+	"fmt"
+	"strings"
+
+	"github.com/LFDT-Lineth/zkc/pkg/schema/module"
+	"github.com/LFDT-Lineth/zkc/pkg/schema/register"
 	"github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/util"
-	"github.com/LFDT-Lineth/zkc/pkg/util/collection/bit"
+	"github.com/LFDT-Lineth/zkc/pkg/util/collection"
+	"github.com/LFDT-Lineth/zkc/pkg/util/collection/array"
 	"github.com/LFDT-Lineth/zkc/pkg/util/source/sexp"
 )
 
@@ -25,7 +32,7 @@ type Constraint[F any] interface {
 	// Accepts determines whether a given constraint accepts a given trace or
 	// not.  If not, a failure is produced.  Otherwise, a bitset indicating
 	// branch coverage is returned.
-	Accepts(trace.Trace[F], AnySchema[F]) (bit.Set, Failure)
+	Accepts(trace.Trace[F], AnySchema[F], Context[F]) Failure
 	// Determine the well-definedness bounds for this constraint in both the
 	// negative (left) or positive (right) directions.  For example, consider an
 	// expression such as "(shift X -1)".  This is technically undefined for the
@@ -42,10 +49,102 @@ type Constraint[F any] interface {
 	// constraints have at least one context (which we can call the "primary"
 	// context).
 	Contexts() []ModuleId
+	// Sets returns the list of set identifiers needed for checking this
+	// constraint (if any).
+	Sets() []SetId
 	// Name returns a unique name for a given constraint.  This is useful purely
 	// for identifying constraints in reports, etc.
 	Name() string
 	// Lisp converts this schema element into a simple S-Expression, for example
 	// so it can be printed.
 	Lisp(AnySchema[F]) sexp.SExp
+}
+
+// Context provides a single reference point for reusing contextual information
+// whilst checking constraints.  For example, it provides cached access to data
+// for lookups to prevent the need to recompute this for individual lookups.
+type Context[F any] interface {
+	// LookupSet returns a given module viewed as a set from the perspective of
+	// a given set of columns, with an optional selector.
+	Get(SetId) collection.Set[[]F]
+}
+
+// SetId provides a generic mechanism for referring to a particular set of data
+// required for constraint checking.
+type SetId struct {
+	mid module.Id
+	sel util.Option[register.Id]
+	row []register.Id
+}
+
+// NewSetId constructs a new set id.
+func NewSetId(mid module.Id, selector util.Option[register.Id], row []register.Id) SetId {
+	return SetId{mid, selector, row}
+}
+
+// Cmp implementation for set.Comparable inteface.
+func (p SetId) Cmp(o SetId) int {
+	if c := cmp.Compare(p.mid, o.mid); c != 0 {
+		return c
+	} else if c := array.Compare(p.row, o.row); c != 0 {
+		return c
+	}
+	//
+	return compareSelectors(p.sel, o.sel)
+}
+
+// Module returns the module to which this identifier refers.
+func (p SetId) Module() module.Id {
+	return p.mid
+}
+
+// HasSelector determines whether or not this identifier has a selector line.
+func (p SetId) HasSelector() bool {
+	return p.sel.HasValue()
+}
+
+// Selector returns the selector line for this identifier, or panics if it has
+// none.
+func (p SetId) Selector() register.Id {
+	return p.sel.Unwrap()
+}
+
+// Width returns the number of data lines for this identifier.
+func (p SetId) Width() uint {
+	return uint(len(p.row))
+}
+
+// Ith returns the ith data line for this identifier.
+func (p SetId) Ith(index uint) register.Id {
+	return p.row[index]
+}
+
+// String returns a (unique) string representation for this set.
+func (p SetId) String() string {
+	var builder strings.Builder
+	//
+	if p.HasSelector() {
+		fmt.Fprintf(&builder, "%x:%x", p.mid, p.sel.Unwrap())
+	} else {
+		fmt.Fprintf(&builder, "%x", p.mid)
+	}
+	//
+	for _, r := range p.row {
+		fmt.Fprintf(&builder, ";%x", r.Unwrap())
+	}
+	//
+	return builder.String()
+}
+
+func compareSelectors(l, r util.Option[register.Id]) int {
+	switch {
+	case l.IsEmpty() && r.IsEmpty():
+		return 0
+	case l.IsEmpty():
+		return -1
+	case r.IsEmpty():
+		return 1
+	default:
+		return l.Unwrap().Cmp(r.Unwrap())
+	}
 }

--- a/pkg/schema/constraint/lookup/constraint.go
+++ b/pkg/schema/constraint/lookup/constraint.go
@@ -14,16 +14,20 @@ package lookup
 
 import (
 	"fmt"
-	"slices"
 
 	"github.com/LFDT-Lineth/zkc/pkg/schema"
 	"github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/util"
-	"github.com/LFDT-Lineth/zkc/pkg/util/collection/bit"
-	"github.com/LFDT-Lineth/zkc/pkg/util/collection/hash"
+	"github.com/LFDT-Lineth/zkc/pkg/util/collection"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
 	"github.com/LFDT-Lineth/zkc/pkg/util/source/sexp"
 )
+
+// Set provides a convenient alias
+type Set[F any] = collection.Set[F]
+
+// SetId provides a convenient alias
+type SetId = schema.SetId
 
 // Constraint (sometimes also called an inclusion constraint) constrains
 // two sets of columns (potentially in different modules). Specifically, every
@@ -108,6 +112,16 @@ func (p Constraint[F]) Contexts() []schema.ModuleId {
 	return contexts
 }
 
+// Sets implementation for schema.Constraint interface.
+func (p Constraint[F]) Sets() (sets []SetId) {
+	//
+	for _, v := range p.Targets {
+		sets = append(sets, v.SetId())
+	}
+	//
+	return sets
+}
+
 // Bounds determines the well-definedness bounds for this constraint for both
 // the negative (left) or positive (right) directions.  Since a lookup is made
 // up of registers (rather than arbitrary expressions), it is always well
@@ -122,18 +136,23 @@ func (p Constraint[F]) Bounds(module uint) util.Bounds {
 // all rows of the source columns.
 //
 //nolint:revive
-func (p Constraint[F]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F]) (bit.Set, schema.Failure) {
+func (p Constraint[F]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F], ctx schema.Context[F]) schema.Failure {
 	var (
-		coverage bit.Set
-		// Insert all active target vectors
-		st = p.insertTargetVectors(tr, sc)
+		// Load target sets
+		targets = loadSets(ctx, p.Targets...)
+		// Initialise read buffer
+		buffer = make([]F, p.Sources[0].Len())
 	)
-	// Check against all active source vectors
-	if err := st.checkSourceVectors(p.Sources, tr); err != nil {
-		return coverage, err
+	// Subset check
+	for _, source := range p.Sources {
+		var trModule = tr.Module(source.Module)
+		// Check each row in the set determined by this vector.
+		if err := p.checkSourceSet(source.SetId(), trModule, targets, buffer); err != nil {
+			return err
+		}
 	}
 	//
-	return coverage, nil
+	return nil
 }
 
 // Lisp converts this schema element into a simple S-Expression, for example
@@ -162,144 +181,67 @@ func (p Constraint[F]) Lisp(mapping schema.AnySchema[F]) sexp.SExp {
 	})
 }
 
-func (p *Constraint[F]) insertTargetVectors(tr trace.Trace[F], sc schema.AnySchema[F]) State[F] {
-	var (
-		st State[F]
-		// Determine width (in columns) of this lookup
-		width uint = p.Sources[0].Len()
-	)
-	// Initialise target state
-	st.handle = p.Handle
-	st.rows = hash.NewSet[hash.Array[F]](tr.Module(p.Targets[0].Module).Height())
-	st.buffer = make([]F, width)
-	// Choose optimised loop
-	for _, target := range p.Targets {
-		var (
-			trModule = tr.Module(target.Module)
-			scModule = sc.Module(target.Module)
-			height   = trModule.Height()
-		)
+// Substitute any matchined labelled constants within this constraint.  Since a
+// lookup is made up of registers (rather than arbitrary expressions), there is
+// nothing to substitute.
+func (p Constraint[F]) Substitute(mapping map[string]F) {
+
+}
+
+// Check that all rows in a given source set are contained within at least one
+// of the given target sets.
+func (p Constraint[F]) checkSourceSet(src SetId, mod trace.Module[F], sets []Set[[]F], buffer []F) schema.Failure {
+	if src.HasSelector() {
+		var selector = src.Selector().Unwrap()
 		//
-		if scModule.IsStatic() {
-			st.insertStaticTarget(scModule)
-		} else if target.HasSelector() {
-			// filtered
-			for i := range int(height) {
-				st.insertFilteredVector(i, target, trModule)
+		for row := range int(mod.Height()) {
+			if !mod.Column(selector).Get(row).IsZero() {
+				if !contains(row, src, mod, sets, buffer) {
+					return &Failure[F]{p.Handle, src, uint(row)}
+				}
 			}
-		} else {
-			// unfiltered
-			for i := range int(height) {
-				st.insertTargetVector(i, target, trModule)
+		}
+	} else {
+		// Optimised path when no selector
+		for row := range int(mod.Height()) {
+			if !contains(row, src, mod, sets, buffer) {
+				return &Failure[F]{p.Handle, src, uint(row)}
 			}
 		}
 	}
 	//
-	return st
+	return nil
 }
 
-// State is just bringing somethings together to make life simpler
-type State[F field.Element[F]] struct {
-	handle string
-	// Set of target rows
-	rows *hash.Set[hash.Array[F]]
-	// Temporary buffer to avoid lots of reallocations.
-	buffer []F
-}
-
-func (p *State[F]) checkSourceVectors(sources []Vector, tr trace.Trace[F]) schema.Failure {
-	// Choose optimised loop
-	for _, source := range sources {
-		var (
-			trModule = tr.Module(source.Module)
-			height   = trModule.Height()
-		)
-		//
-		if source.HasSelector() {
-			// filtered
-			for i := range int(height) {
-				if err := p.checkFilteredSourceVector(i, source, trModule); err != nil {
-					return err
-				}
-			}
-		} else {
-			// unfiltered
-			for i := range int(height) {
-				if err := p.checkSourceVector(i, source, trModule); err != nil {
-					return err
-				}
-			}
+// check whether the given source row is contained within any of the given sets.
+// A temporary buffer of sufficient width is provided to avoid memory
+// allocation.
+func contains[F field.Element[F]](row int, src SetId, mod trace.Module[F], sets []Set[[]F], buffer []F) bool {
+	// Read registers into buffer
+	for i := range src.Width() {
+		var rid = src.Ith(i).Unwrap()
+		// Read given row
+		buffer[i] = mod.Column(rid).Get(row)
+	}
+	// Check for containment
+	for _, set := range sets {
+		if set.Contains(buffer) {
+			return true
 		}
 	}
-	// success
-	return nil
+	//
+	return false
 }
 
-func (p *State[F]) insertFilteredVector(k int, vec Vector, trMod trace.Module[F]) {
-	// If row selected, then insert contents!
-	if isSelected(k, vec, trMod) {
-		p.insertTargetVector(k, vec, trMod)
-	}
-}
-
-func (p *State[F]) insertTargetVector(k int, vec Vector, trModule trace.Module[F]) {
-	// Read each register of this vector
-	p.readRegisters(k, vec, trModule)
-	// Insert item whilst checking whether the buffer was consumed or not
-	if !p.rows.Insert(hash.NewArray(p.buffer)) {
-		// Yes, buffer consumed.  Therefore, construct fresh buffer to avoid
-		// aliasing the value now stored in the hash set.
-		p.buffer = slices.Clone(p.buffer)
-	}
-}
-
-func (p *State[F]) insertStaticTarget(scModule schema.Module[F]) {
+// Load those sets from the context corresponding to the given vectors.
+func loadSets[F field.Element[F]](ctx schema.Context[F], vecs ...Vector) []Set[[]F] {
 	var (
-		contents = scModule.StaticContents()
+		sets = make([]Set[[]F], len(vecs))
 	)
-	// Insert all rows
-	for _, row := range contents {
-		p.rows.Insert(hash.NewArray(row))
-	}
-}
-
-func (p *State[F]) checkFilteredSourceVector(k int, vec Vector, trModule trace.Module[F]) schema.Failure {
-	// If row selected, then check contents!
-	if isSelected(k, vec, trModule) {
-		return p.checkSourceVector(k, vec, trModule)
+	// Load target sets
+	for i, v := range vecs {
+		sets[i] = ctx.Get(v.SetId())
 	}
 	//
-	return nil
-}
-
-func (p *State[F]) checkSourceVector(k int, vec Vector, trModule trace.Module[F]) schema.Failure {
-	// Read each register of this vector
-	p.readRegisters(k, vec, trModule)
-	// Check whether contained.
-	if !p.rows.Contains(hash.NewArray(p.buffer)) {
-		// Construct failure
-		return &Failure[F]{p.handle, vec.Module, slices.Clone(vec.Registers), uint(k)}
-	}
-	// success
-	return nil
-}
-
-// readRegisters reads the value held in each register of the given vector on
-// the given row into the temporary buffer.
-func (p *State[F]) readRegisters(k int, vec Vector, trModule trace.Module[F]) {
-	for i, rid := range vec.Registers {
-		p.buffer[i] = trModule.Column(rid.Unwrap()).Get(k)
-	}
-}
-
-// isSelected determines whether or not the given row of the given vector is
-// selected.  A row without a selector is always selected; otherwise, it is
-// selected when its selector is non-zero.
-func isSelected[F field.Element[F]](k int, vec Vector, trModule trace.Module[F]) bool {
-	// If no selector, then always selected
-	if !vec.HasSelector() {
-		return true
-	}
-	// Otherwise, selected when selector non-zero.
-	return !trModule.Column(vec.Selector.Unwrap().Unwrap()).Get(k).IsZero()
+	return sets
 }

--- a/pkg/schema/constraint/lookup/failure.go
+++ b/pkg/schema/constraint/lookup/failure.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 
 	"github.com/LFDT-Lineth/zkc/pkg/schema"
-	"github.com/LFDT-Lineth/zkc/pkg/schema/register"
 	"github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/util/collection/set"
 )
@@ -25,10 +24,8 @@ import (
 type Failure[F any] struct {
 	// Handle of the failing constraint
 	Handle string
-	// Relevant context for source registers.
-	Context schema.ModuleId
-	// Source registers whose values were missing
-	Sources []register.Id
+	// SourceId gives the set identifier of the source
+	SourceId schema.SetId
 	// Row on which the constraint failed
 	Row uint
 }
@@ -46,8 +43,10 @@ func (p *Failure[F]) String() string {
 func (p *Failure[F]) RequiredCells(_ trace.Trace[F]) *set.AnySortedSet[trace.CellRef] {
 	res := set.NewAnySortedSet[trace.CellRef]()
 	// Handle registers
-	for _, rid := range p.Sources {
-		ref := trace.NewColumnRef(p.Context, rid)
+	for i := range p.SourceId.Width() {
+		var rid = p.SourceId.Ith(i)
+		//
+		ref := trace.NewColumnRef(p.SourceId.Module(), rid)
 		res.Insert(trace.NewCellRef(ref, int(p.Row)))
 	}
 	//

--- a/pkg/schema/constraint/lookup/vector.go
+++ b/pkg/schema/constraint/lookup/vector.go
@@ -76,6 +76,11 @@ func (p *Vector) Ith(index uint) register.Id {
 	return p.Registers[index]
 }
 
+// SetId returns the set identifier associated with this vector.
+func (p *Vector) SetId() schema.SetId {
+	return schema.NewSetId(p.Module, p.Selector, p.Registers)
+}
+
 // Len returns the number of items in this lookup vector.  Note this doesn't
 // include the selector (since this is optional anyway).
 func (p *Vector) Len() uint {

--- a/pkg/schema/constraint/ranged/constraint.go
+++ b/pkg/schema/constraint/ranged/constraint.go
@@ -20,7 +20,6 @@ import (
 	"github.com/LFDT-Lineth/zkc/pkg/schema/register"
 	"github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/util"
-	"github.com/LFDT-Lineth/zkc/pkg/util/collection/bit"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
 	"github.com/LFDT-Lineth/zkc/pkg/util/source/sexp"
 )
@@ -82,6 +81,11 @@ func (p Constraint[F]) Contexts() []schema.ModuleId {
 	return []schema.ModuleId{p.Context}
 }
 
+// Sets implementation for schema.Constraint interface.
+func (p Constraint[F]) Sets() []schema.SetId {
+	return nil
+}
+
 // Bounds determines the well-definedness bounds for this constraint for both
 // the negative (left) or positive (right) directions.  Since a range constraint
 // is made up of registers (rather than arbitrary expressions), it is always
@@ -96,16 +100,14 @@ func (p Constraint[F]) Bounds(module uint) util.Bounds {
 // nil otherwise return an error.
 //
 //nolint:revive
-func (p Constraint[F]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F]) (bit.Set, schema.Failure) {
-	var coverage bit.Set
-	//
+func (p Constraint[F]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F], _ schema.Context[F]) schema.Failure {
 	for i := range p.Sources {
 		if err := p.accepts(i, tr); err != nil {
-			return coverage, err
+			return err
 		}
 	}
 	// All good
-	return coverage, nil
+	return nil
 }
 
 // Lisp converts this schema element into a simple S-Expression, for example so

--- a/pkg/schema/constraint/vanishing/constraint.go
+++ b/pkg/schema/constraint/vanishing/constraint.go
@@ -20,7 +20,6 @@ import (
 	"github.com/LFDT-Lineth/zkc/pkg/schema/constraint"
 	"github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/util"
-	"github.com/LFDT-Lineth/zkc/pkg/util/collection/bit"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
 	"github.com/LFDT-Lineth/zkc/pkg/util/source/sexp"
 )
@@ -75,6 +74,11 @@ func (p Constraint[F, T]) Contexts() []schema.ModuleId {
 	return []schema.ModuleId{p.Context}
 }
 
+// Sets implementation for schema.Constraint interface.
+func (p Constraint[F, T]) Sets() []schema.SetId {
+	return nil
+}
+
 // Bounds determines the well-definedness bounds for this constraint for both
 // the negative (left) or positive (right) directions.  For example, consider an
 // expression such as "(shift X -1)".  This is technically undefined for the
@@ -94,7 +98,7 @@ func (p Constraint[F, T]) Bounds(module uint) util.Bounds {
 // of a table.  If so, return nil otherwise return an error.
 //
 //nolint:revive
-func (p Constraint[F, T]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F]) (bit.Set, schema.Failure) {
+func (p Constraint[F, T]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F], _ schema.Context[F]) schema.Failure {
 	var (
 		// Handle is used for error reporting.
 		handle = constraint.DetermineHandle(p.Handle, p.Context, tr)
@@ -120,23 +124,16 @@ func (p Constraint[F, T]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F]) (bi
 	} else {
 		start = uint(domain)
 	}
-	//
-	var coverage bit.Set
 	// Check specific row
-	err, id := HoldsLocally(start, handle, p.Constraint, p.Context, trModule, scModule)
-	//
-	coverage.Insert(id)
-	//
-	return coverage, err
+	return HoldsLocally(start, handle, p.Constraint, p.Context, trModule, scModule)
 }
 
 // HoldsGlobally checks whether a given expression vanishes (i.e. evaluates to
 // zero) for all rows of a trace.  If not, report an appropriate error.
 func HoldsGlobally[F field.Element[F], T term.Testable[F]](handle string, ctx schema.ModuleId, constraint T,
-	trMod trace.Module[F], scMod schema.Module[F]) (bit.Set, schema.Failure) {
+	trMod trace.Module[F], scMod schema.Module[F]) schema.Failure {
 	//
 	var (
-		coverage bit.Set
 		// Determine height of enclosing module
 		height = trMod.Height()
 		// Determine well-definedness bounds for this constraint
@@ -146,33 +143,31 @@ func HoldsGlobally[F field.Element[F], T term.Testable[F]](handle string, ctx sc
 	if bounds.End < height {
 		// Check all in-bounds values
 		for k := bounds.Start; k < (height - bounds.End); k++ {
-			err, id := HoldsLocally(k, handle, constraint, ctx, trMod, scMod)
+			err := HoldsLocally(k, handle, constraint, ctx, trMod, scMod)
 			if err != nil {
-				return coverage, err
+				return err
 			}
-			// Update coverage
-			coverage.Insert(id)
 		}
 	}
 	// Success
-	return coverage, nil
+	return nil
 }
 
 // HoldsLocally checks whether a given constraint holds (e.g. vanishes) on a
 // specific row of a trace. If not, report an appropriate error.
 func HoldsLocally[F field.Element[F], T term.Testable[F]](k uint, handle string, term T, ctx schema.ModuleId,
-	trMod trace.Module[F], scMod schema.Module[F]) (schema.Failure, uint) {
+	trMod trace.Module[F], scMod schema.Module[F]) schema.Failure {
 	//
-	ok, id, err := term.TestAt(int(k), trMod, scMod)
+	ok, _, err := term.TestAt(int(k), trMod, scMod)
 	// Check for errors
 	if err != nil {
-		return constraint.NewInternalFailure[F](handle, ctx, k, term, err.Error()), id
+		return constraint.NewInternalFailure[F](handle, ctx, k, term, err.Error())
 	} else if !ok {
 		// Evaluation failure
-		return &Failure[F]{handle, term, ctx, k}, id
+		return &Failure[F]{handle, term, ctx, k}
 	}
 	// Success
-	return nil, id
+	return nil
 }
 
 // Lisp converts this constraint into an S-Expression.

--- a/pkg/schema/context.go
+++ b/pkg/schema/context.go
@@ -1,0 +1,349 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package schema
+
+import (
+	"fmt"
+	"iter"
+	"runtime"
+	"slices"
+
+	"github.com/LFDT-Lineth/zkc/pkg/trace"
+	"github.com/LFDT-Lineth/zkc/pkg/util"
+	"github.com/LFDT-Lineth/zkc/pkg/util/collection"
+	"github.com/LFDT-Lineth/zkc/pkg/util/collection/hash"
+	"github.com/LFDT-Lineth/zkc/pkg/util/collection/set"
+	"github.com/LFDT-Lineth/zkc/pkg/util/field"
+)
+
+// Set provides a convenient alias
+type Set[F field.Element[F]] = *hash.Set[hash.Array[F]]
+
+// chunksPerWorker determines how many chunks, on average, each available
+// processor should receive when building sets in parallel.  Using more
+// chunks than workers allows the workload to be rebalanced dynamically: a
+// worker which finishes its chunks early can pick up further chunks, rather
+// than sitting idle whilst a single large chunk is still being built
+// elsewhere.
+const chunksPerWorker = 10
+
+// determineChunkSize computes a suitable chunk size for parallel set
+// construction, based on the total number of candidate rows across all sets
+// and the number of available processors.  Aiming for chunksPerWorker chunks
+// per processor balances parallelism against the overhead of the reduce
+// phase (more, smaller chunks means more merging work later).
+func determineChunkSize(totalRows uint) uint {
+	return max(1, totalRows/(uint(runtime.NumCPU())*chunksPerWorker))
+}
+
+// setChunk identifies a sub-range of rows within the set determined by a
+// given SetId.
+type setChunk struct {
+	id         SetId
+	start, end uint
+}
+
+// SeqBuildContext constructs the context from a given schema and trace.
+// Essentially, this means traversing the schema looking for lookups and
+// constructing their sets.  NOTE: this is done sequentially
+func SeqBuildContext[F field.Element[F]](tr trace.Trace[F], sc AnySchema[F]) Context[F] {
+	var (
+		stats   = util.NewPerfStats()
+		context = make(map[string]*hash.Set[hash.Array[F]])
+		sids    = determineSets(sc)
+	)
+	// sequential set construction (as a single chunk per set)
+	for _, sid := range sids {
+		height := setHeight(sid, tr, sc)
+		// Construct data for this set
+		context[sid.String()] = buildSetChunk(setChunk{sid, 0, height}, tr, sc)
+	}
+	//
+	stats.Log(fmt.Sprintf("Building context (%d sets; sequential)", len(context)))
+	//
+	return contextImpl[F]{context}
+}
+
+// ParBuildContext constructs the context from a given schema and trace, using
+// a map-reduce strategy.  Each set is first split into one or more row-range
+// chunks (so a single large set does not bottleneck the whole process), which
+// are then constructed in parallel via util.ParallelMap (the "map" phase).
+// Chunks belonging to the same set are then merged back together (the
+// "reduce" phase), which is likewise done in parallel across sets.
+func ParBuildContext[F field.Element[F]](tr trace.Trace[F], sc AnySchema[F]) Context[F] {
+	var (
+		stats          = util.NewPerfStats()
+		context        = make(map[string]*hash.Set[hash.Array[F]])
+		sids           = determineSets(sc)
+		chunks, counts = determineChunks(sids, tr, sc)
+		// map phase: build every chunk in parallel
+		partials = util.ParallelMap(chunks, func(_ uint, c setChunk) Set[F] {
+			return buildSetChunk(c, tr, sc)
+		})
+		// group chunk results by their originating set.  Since chunks are
+		// generated in sids order (see determineChunks), the ith set's chunks
+		// form a contiguous run of counts[i] entries within partials.
+		groups = make([][]Set[F], len(sids))
+	)
+	//
+	for i, offset := 0, uint(0); i < len(sids); i++ {
+		groups[i] = partials[offset : offset+counts[i]]
+		offset += counts[i]
+	}
+	// reduce phase: merge the chunks of each set in parallel
+	merged := util.ParallelMap(sids, func(i uint, sid SetId) Set[F] {
+		return mergeSets(groups[i])
+	})
+	//
+	for i, sid := range sids {
+		context[sid.String()] = merged[i]
+	}
+	//
+	stats.Log(fmt.Sprintf("Building context (%d sets, %d chunks; parallel)", len(sids), len(chunks)))
+	//
+	return contextImpl[F]{context}
+}
+
+// determineChunks splits every set identified by sids into one or more
+// row-range chunks suitable for parallel construction.  The chunk size is
+// determined dynamically from the total number of candidate rows across all
+// sets (see determineChunkSize), rather than being fixed, so it scales with
+// both the workload and the number of available processors.  Sets are always
+// given at least one chunk (which may be empty), so every set ends up
+// represented in the resulting context.  Alongside the flat chunk list, it
+// returns the number of chunks generated for each set (aligned with sids), so
+// callers can recover the chunks belonging to a given set without a map
+// lookup.
+func determineChunks[F field.Element[F]](sids []SetId, tr trace.Trace[F], sc AnySchema[F]) ([]setChunk, []uint) {
+	var (
+		heights = make([]uint, len(sids))
+		total   uint
+	)
+	// Determine height of every set, and the total number of rows overall.
+	for i, sid := range sids {
+		heights[i] = setHeight(sid, tr, sc)
+		total += heights[i]
+	}
+	//
+	var (
+		size   = determineChunkSize(total)
+		chunks []setChunk
+		counts = make([]uint, len(sids))
+	)
+	//
+	for i, height := range heights {
+		if height == 0 {
+			chunks = append(chunks, setChunk{sids[i], 0, 0})
+			counts[i] = 1
+
+			continue
+		}
+		//
+		for start := uint(0); start < height; start += size {
+			chunks = append(chunks, setChunk{sids[i], start, min(start+size, height)})
+			counts[i]++
+		}
+	}
+	//
+	return chunks, counts
+}
+
+// setHeight determines the number of candidate (static or dynamic) rows from
+// which the given set is constructed.
+func setHeight[F field.Element[F]](id SetId, tr trace.Trace[F], sc AnySchema[F]) uint {
+	scModule := sc.Module(id.Module())
+	//
+	if scModule.IsStatic() {
+		return uint(len(scModule.StaticContents()))
+	}
+	//
+	return tr.Module(id.Module()).Height()
+}
+
+// mergeSets combines one or more partial sets (constructed from disjoint
+// row-range chunks of the same underlying set) into a single set.
+func mergeSets[F field.Element[F]](partials []Set[F]) Set[F] {
+	// Common case: set was constructed as a single chunk.
+	if len(partials) == 1 {
+		return partials[0]
+	}
+	//
+	var size uint
+	//
+	for _, p := range partials {
+		size += p.Size()
+	}
+	//
+	merged := hash.NewSet[hash.Array[F]](size >> 4)
+	//
+	for _, p := range partials {
+		for v := range p.Iter() {
+			merged.Insert(v)
+		}
+	}
+	//
+	return merged
+}
+
+// DetermineSets extracts all unique set identifiers from lookup constraints.
+func determineSets[F field.Element[F]](sc AnySchema[F]) []SetId {
+	var sets set.AnySortedSet[SetId]
+	//
+	for iter := sc.Constraints(); iter.HasNext(); {
+		var ith = iter.Next()
+		//
+		for _, sid := range ith.Sets() {
+			sets.Insert(sid)
+		}
+	}
+	//
+	return sets.ToArray()
+}
+
+// buildSetChunk constructs the (partial) set of rows determined by a given
+// chunk.
+func buildSetChunk[F field.Element[F]](c setChunk, tr trace.Trace[F], sc AnySchema[F]) Set[F] {
+	scModule := sc.Module(c.id.Module())
+	//
+	if scModule.IsStatic() {
+		return buildStaticSetChunk(c, scModule)
+	}
+	//
+	return buildDynamicSetChunk(c, tr.Module(c.id.Module()))
+}
+
+func buildStaticSetChunk[F field.Element[F]](c setChunk, sm Module[F]) Set[F] {
+	var (
+		buffer   = make([]F, c.id.Width())
+		contents = sm.StaticContents()[c.start:c.end]
+		data     = hash.NewSet[hash.Array[F]](uint(len(contents)) >> 4)
+	)
+	// Insert all selected rows within this chunk
+	for _, row := range contents {
+		if isStaticSelected(c.id, row) {
+			// Read each register of this vector
+			readStaticRegisters(c.id, row, buffer)
+			// Insert item whilst checking whether the buffer was consumed or not
+			if !data.Insert(hash.NewArray(buffer)) {
+				// Yes, buffer consumed.  Therefore, construct fresh buffer to avoid
+				// aliasing the value now stored in the hash set.
+				buffer = slices.Clone(buffer)
+			}
+		}
+	}
+	//
+	return data
+}
+
+func buildDynamicSetChunk[F field.Element[F]](c setChunk, trModule trace.Module[F]) Set[F] {
+	var (
+		buffer = make([]F, c.id.Width())
+		data   = hash.NewSet[hash.Array[F]]((c.end - c.start) >> 4)
+	)
+	//
+	for i := int(c.start); i < int(c.end); i++ {
+		if isSelected(i, c.id, trModule) {
+			// Read each register of this vector
+			readRegisters(i, c.id, trModule, buffer)
+			// Insert item whilst checking whether the buffer was consumed or not
+			if !data.Insert(hash.NewArray(buffer)) {
+				// Yes, buffer consumed.  Therefore, construct fresh buffer to avoid
+				// aliasing the value now stored in the hash set.
+				buffer = slices.Clone(buffer)
+			}
+		}
+	}
+	//
+	return data
+}
+
+// readRegisters reads the value held in each register of the given vector on
+// the given row into the temporary buffer.
+func readRegisters[F field.Element[F]](k int, id SetId, trModule trace.Module[F], buffer []F) {
+	for i := range id.Width() {
+		rid := id.Ith(i)
+		buffer[i] = trModule.Column(rid.Unwrap()).Get(k)
+	}
+}
+
+// readStaticRegisters reads the value held in each register of the given vector
+// on the given row into the temporary buffer.
+func readStaticRegisters[F field.Element[F]](id SetId, row []F, buffer []F) {
+	for i := range id.Width() {
+		rid := id.Ith(i)
+		buffer[i] = row[rid.Unwrap()]
+	}
+}
+
+// isSelected determines whether or not the given row of the given vector is
+// selected.  A row without a selector is always selected; otherwise, it is
+// selected when its selector is non-zero.
+func isSelected[F field.Element[F]](k int, id SetId, trModule trace.Module[F]) bool {
+	// If no selector, then always selected
+	if !id.HasSelector() {
+		return true
+	}
+	// Otherwise, selected when selector non-zero.
+	return !trModule.Column(id.Selector().Unwrap()).Get(k).IsZero()
+}
+
+// isStaticSelected determines whether or not the given row of the given vector
+// is selected.  A row without a selector is always selected; otherwise, it is
+// selected when its selector is non-zero.
+func isStaticSelected[F field.Element[F]](id SetId, row []F) bool {
+	// If no selector, then always selected
+	if !id.HasSelector() {
+		return true
+	}
+	// Otherwise, selected when selector non-zero.
+	return !row[id.Selector().Unwrap()].IsZero()
+}
+
+// ============================================================================
+// Context Implementation
+// ============================================================================
+
+// Context provides suitable constrant context
+type contextImpl[F field.Element[F]] struct {
+	sets map[string]*hash.Set[hash.Array[F]]
+}
+
+// Get implementation of Context interface.
+func (p contextImpl[F]) Get(id SetId) collection.Set[[]F] {
+	if set, ok := p.sets[id.String()]; ok {
+		return contextSet[F]{set}
+	}
+	//
+	panic(fmt.Sprintf("unknown set %s in context", id.String()))
+}
+
+// An adaptor to make a Set[hash.Array[F]] look like a Set[[]F]
+type contextSet[F field.Element[F]] struct {
+	data *hash.Set[hash.Array[F]]
+}
+
+// Contains implementation for collection.Set interface
+func (p contextSet[F]) Contains(row []F) bool {
+	return p.data.Contains(hash.NewArray(row))
+}
+
+// Iter implementation of Set interface.
+func (p contextSet[F]) Iter() iter.Seq[[]F] {
+	return func(yield func([]F) bool) {
+		for v := range p.data.Iter() {
+			if !yield(v.Elements()) {
+				return
+			}
+		}
+	}
+}

--- a/pkg/schema/schemas.go
+++ b/pkg/schema/schemas.go
@@ -18,9 +18,10 @@ import (
 
 	tr "github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/util"
-	"github.com/LFDT-Lineth/zkc/pkg/util/collection/bit"
+	"github.com/LFDT-Lineth/zkc/pkg/util/collection/array"
 	"github.com/LFDT-Lineth/zkc/pkg/util/collection/iter"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
+	log "github.com/sirupsen/logrus"
 )
 
 // RequiredPaddingRows determines the number of additional (spillage / padding)
@@ -98,18 +99,18 @@ func defensivePadding[F any](module uint, schema AnySchema[F]) uint {
 // constraint which does not hold.
 //
 //nolint:revive
-func Accepts[F field.Element[F], C Constraint[F]](parallel bool, batchsize uint, schema Schema[F, C],
+func Accepts[F field.Element[F], C Constraint[F]](parallel bool, schema Schema[F, C],
 	trace tr.Trace[F]) []Failure {
 	//
-	return accepts(parallel, batchsize, schema.Constraints(), trace, schema, "Constraint")
+	return accepts(parallel, schema.Constraints(), trace, schema)
 }
 
 //nolint:revive
-func accepts[F field.Element[F], C Constraint[F]](parallel bool, batchsize uint, iter iter.Iterator[C],
-	trace tr.Trace[F], schema Schema[F, C], kind string) []Failure {
+func accepts[F field.Element[F], C Constraint[F]](parallel bool, iter iter.Iterator[C],
+	trace tr.Trace[F], schema Schema[F, C]) []Failure {
 	//
 	if parallel {
-		return parallelAccepts(batchsize, iter, trace, schema, kind)
+		return parallelAccepts(iter, trace, schema)
 	}
 	// sequential
 	return sequentialAccepts(iter, trace, schema)
@@ -118,12 +119,16 @@ func accepts[F field.Element[F], C Constraint[F]](parallel bool, batchsize uint,
 func sequentialAccepts[F field.Element[F], C Constraint[F]](iter iter.Iterator[C], trace tr.Trace[F],
 	schema Schema[F, C]) []Failure {
 	//
-	errors := make([]Failure, 0)
+	var (
+		context = SeqBuildContext(trace, Any(schema))
+		errors  = make([]Failure, 0)
+	)
+
 	//
 	for iter.HasNext() {
 		ith := iter.Next()
 		//
-		_, err := ith.Accepts(trace, Any(schema))
+		err := ith.Accepts(trace, Any(schema), context)
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -132,81 +137,48 @@ func sequentialAccepts[F field.Element[F], C Constraint[F]](iter iter.Iterator[C
 	return errors
 }
 
-func parallelAccepts[F field.Element[F], C Constraint[F]](batchsize uint, iter iter.Iterator[C], trace tr.Trace[F],
-	schema Schema[F, C], kind string) []Failure {
-	//
-	errors := make([]Failure, 0)
-	// Initialise batch number (for debugging purposes)
-	batch := uint(0)
-	// Process constraints in batches
-	for iter.HasNext() {
-		errs := processConstraintBatch(kind, batch, batchsize, iter, trace, schema)
-		errors = append(errors, errs...)
-		// Increment batch number
-		batch++
-	}
-	// Success
-	return errors
-}
-
-// Process a given set of constraints in a single batch whilst recording all constraint failures.
-func processConstraintBatch[F field.Element[F], C Constraint[F]](logtitle string, batch uint, batchsize uint,
-	iter iter.Iterator[C], trace tr.Trace[F], schema Schema[F, C]) []Failure {
-	//
-	n := uint(0)
-	c := make(chan batchOutcome, batchsize)
-	errors := make([]Failure, 0)
-	stats := util.NewPerfStats()
-	// Launch at most 100 go-routines.
-	for ; n < batchsize && iter.HasNext(); n++ {
-		// Get ith constraint
-		ith := iter.Next()
-		// Launch checker for constraint
-		go func() {
-			var (
-				context = ith.Contexts()[0]
-				name    = ith.Name()
-				cov     bit.Set
-			)
-			// Setup panic intercept
-			defer func() {
-				var err = recover()
-				//
-				if err != nil {
-					var (
-						buf [2048]byte
-						n   = runtime.Stack(buf[:], false)
-					)
-					c <- batchOutcome{context, name, cov, &PanicFailure{
-						fmt.Sprintf("%v", err), buf[:n],
-					}}
-				}
-			}()
-			// Check and send outcome back
-			cov, err := ith.Accepts(trace, Any(schema))
-			//
-			c <- batchOutcome{context, name, cov, err}
-		}()
-	}
-	//
-	for i := uint(0); i < n; i++ {
-		p := <-c
-		// Read from channel
-		if p.error != nil {
-			errors = append(errors, p.error)
+func parallelAccepts[F field.Element[F], C Constraint[F]](iter iter.Iterator[C], trace tr.Trace[F],
+	schema Schema[F, C]) (errors []Failure) {
+	var (
+		context = ParBuildContext(trace, Any(schema))
+		// Collect all constraints into a slice so we can use ParallelMap.
+		constraints = iter.Collect()
+	)
+	// Process all constraints in parallel using a worker pool.
+	errors = util.ParallelMap(constraints, func(i uint, constraint C) Failure {
+		if i%1000 == 0 {
+			var percent float64 = float64(100*i) / float64(len(constraints))
+			log.Debug(fmt.Sprintf("Checking constraints [%0.1f%%]", percent))
 		}
-	}
-	// Log stats about this batch
-	stats.Log(fmt.Sprintf("%s batch %d (%d items)", logtitle, batch, n))
+		//
+		return processConstraint(constraint, trace, schema, context)
+	})
+
 	//
-	return errors
+	return array.Filter(errors, func(f Failure) bool { return f != nil })
 }
 
-type batchOutcome struct {
-	module uint
-	handle string
-	data   bit.Set
-	error  Failure
+// processConstraint checks a given constraint against the trace, intercepting any
+// panic and converting it into a PanicFailure.
+func processConstraint[F field.Element[F], C Constraint[F]](ith C, trace tr.Trace[F], schema Schema[F, C],
+	ctx Context[F]) (res Failure) {
+	// Setup panic intercept
+	defer func() {
+		var err = recover()
+		//
+		if err != nil {
+			var (
+				buf [2048]byte
+				n   = runtime.Stack(buf[:], false)
+			)
+			// override return
+			res = &PanicFailure{fmt.Sprintf("%v", err), buf[:n]}
+		}
+	}()
+	// Check and send outcome back
+	err := ith.Accepts(trace, Any(schema), ctx)
+	//
+	return err
 }
 
 // PanicFailure indicates that a panic arose during constraint checking, rather

--- a/pkg/test/util/check_legacy.go
+++ b/pkg/test/util/check_legacy.go
@@ -232,7 +232,7 @@ func checkTrace[F field.Element[F], C sc.Constraint[F]](t *testing.T, tf lt.Trac
 		t.Errorf("Trace expansion failed (%s): %s", id.String(), errs)
 	} else {
 		// Check Constraints
-		errs := sc.Accepts(id.parallel, 128, schema, tr)
+		errs := sc.Accepts(id.parallel, schema, tr)
 		// Determine whether trace accepted or not.
 		accepted := len(errs) == 0
 		// Process what happened versus what was supposed to happen.

--- a/pkg/util/collection/hash/hash_key.go
+++ b/pkg/util/collection/hash/hash_key.go
@@ -106,6 +106,11 @@ func (p Array[F]) Equals(other Array[F]) bool {
 	return true
 }
 
+// Elements returns the underlying elements.
+func (p Array[F]) Elements() []F {
+	return p.elements
+}
+
 // Hash generat6es a 64-bit hashcode from the underlying bytes array.
 func (p Array[F]) Hash() uint64 {
 	// FNV1a hash implementation

--- a/pkg/util/collection/hash/hash_set.go
+++ b/pkg/util/collection/hash/hash_set.go
@@ -14,6 +14,7 @@ package hash
 
 import (
 	"fmt"
+	"iter"
 	"strings"
 )
 
@@ -41,6 +42,19 @@ func (p *Set[T]) Size() uint {
 	}
 
 	return count
+}
+
+// Iter returns an iterator over the items contained in this hashset.
+func (p *Set[T]) Iter() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for _, v := range p.items {
+			for _, v := range v.items {
+				if !yield(v) {
+					return
+				}
+			}
+		}
+	}
 }
 
 // MaxBucket returns the size of the largest bucket.

--- a/pkg/util/collection/hash/hashset_test.go
+++ b/pkg/util/collection/hash/hashset_test.go
@@ -14,6 +14,7 @@ package hash
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"testing"
 
@@ -95,6 +96,12 @@ func check_HashSet(t *testing.T, items []uint) {
 	for _, ith := range items {
 		if !set.Contains(testKey{ith}) {
 			t.Errorf("missing item %d: %s", ith, set.String())
+		}
+	}
+	// Sanity check iterator
+	for val := range set.Iter() {
+		if !slices.Contains(items, val.value) {
+			t.Errorf("unknown item %d: %s", val, set.String())
 		}
 	}
 }

--- a/pkg/util/collection/types.go
+++ b/pkg/util/collection/types.go
@@ -1,0 +1,23 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package collection
+
+import "iter"
+
+// Set provides a generic interface describing a set.
+type Set[T any] interface {
+	// Contains checks whether a given element is in the set.
+	Contains(T) bool
+	// Iter iterates over all elements in the set.
+	Iter() iter.Seq[T]
+}

--- a/pkg/util/parallel.go
+++ b/pkg/util/parallel.go
@@ -12,95 +12,46 @@
 // SPDX-License-Identifier: Apache-2.0
 package util
 
-// ParBatchJob represents an atomic division of work which is composed of one or
-// more jobs.  The idea is that all of these jobs must be computed together in
-// one large batch, and cannot be further broken down.
-type ParBatchJob interface {
-	// Get the job identifies for all jobs in this batch.
-	Jobs() []uint
-	// Get the jobs on which this at least one job in this batch dependend.  In
-	// otherwords, all of the return jobs must be complete before this batch can
-	// run.
-	Dependencies() []uint
-	// Run this batch job
-	Run() error
-}
+import (
+	"runtime"
+	"sync"
+)
 
-// ParExec executes a set of jobs in parallel using go-routines.
-func ParExec[J ParBatchJob](worklist []J) error {
-	var next J
-	// Initialise the done set
-	todo := initToDoList(worklist)
-	// Iterate until all batches complete
-	for len(worklist) > 0 {
-		next, worklist = selectBatch(todo, worklist)
-		// Execute next batch
-		if err := next.Run(); err != nil {
-			return err
-		}
-		// Mark all jobs in batch as done
-		for _, j := range next.Jobs() {
-			todo[j] = false
-		}
-	}
-	// Done
-	return nil
-}
-
-// Initialise the set of jobs which remain to be completed.  Jobs which are not
-// present in the batch are assumed to be already completed.
-func initToDoList[J ParBatchJob](batches []J) []bool {
-	n := uint(0)
-	// Determine largest job identifier
-	for _, b := range batches {
-		for _, j := range b.Jobs() {
-			n = max(n, j+1)
-		}
-	}
-	// Construct todo list
-	todo := make([]bool, n)
-	// Initialise jobs
-	for _, b := range batches {
-		for _, j := range b.Jobs() {
-			todo[j] = true
-		}
-	}
-	// Done
-	return todo
-}
-
-// Select and remove the first "ready" job from the worklist.  A job is ready if
-// all of its dependencies are completed.  If no such job exists, then its an
-// error.
-func selectBatch[J ParBatchJob](todo []bool, worklist []J) (J, []J) {
-	for i, b := range worklist {
-		if readyJob(todo, b) {
-			// Following mechanism for removing element from worklist is
-			// temporary.  It works on the assumption of sequential execution,
-			// where the head is always selected first.  This obviously won't
-			// work for true parallel execution.
-			if i != 0 {
-				panic("internal failure")
+// ParallelMap maps every element in a given array to a corresponding element of
+// another type.  This is parallelised using a worker pool whose size is bounded
+// by the number of available CPUs, making it safe to use even with large input
+// slices or relatively cheap mapper functions.
+func ParallelMap[T any, S any](items []T, mapper func(uint, T) S) []S {
+	var (
+		results = make([]S, len(items))
+		n       = len(items)
+		// Determine number of workers.
+		workers = min(n, runtime.NumCPU())
+		// worker pool
+		wg sync.WaitGroup
+		// Channel from which workers pull indices to process.
+		ch = make(chan int, workers)
+	)
+	// Start workers.
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		//
+		go func() {
+			defer wg.Done()
+			// Process indices until channel is closed.
+			for i := range ch {
+				results[i] = mapper(uint(i), items[i])
 			}
-			//
-			return b, worklist[1:]
-		}
+		}()
 	}
+	// Distribute work.
+	for i := range n {
+		ch <- i
+	}
+	// Signal workers to stop.
+	close(ch)
+	// Wait for all workers to finish.
+	wg.Wait()
 	//
-	panic("no job is ready to run")
-}
-
-// ReadyJob determines whether or not a given batch job is ready to run, or not.
-// Specifically, a job is ready when all its dependencies have been completed.
-func readyJob[J ParBatchJob](todo []bool, batch J) bool {
-	// Check dependencies
-	for _, j := range batch.Dependencies() {
-		if todo[j] {
-			// Dependent job remains to be done.  Therefore, this job is not
-			// ready to run.
-			return false
-		}
-	}
-	// All dependencies done, so this batch is ready.
-	return true
+	return results
 }

--- a/pkg/zkc/constraints/binary_file.go
+++ b/pkg/zkc/constraints/binary_file.go
@@ -274,7 +274,7 @@ func (p *BinaryFile[F]) Check(tr trace.Trace[F], config TraceConfig) []schema.Fa
 		stats = util.NewPerfStats()
 	)
 	// Check constraints
-	failures := schema.Accepts(config.Parallelism(), config.BatchSize(), sc, tr)
+	failures := schema.Accepts(config.Parallelism(), sc, tr)
 	// Log stats
 	stats.Log("Constraint checking")
 	//


### PR DESCRIPTION
This adds a new centralised process called "context construction" which pre-generates the source / target sets required for checking a lookup constraint.  The primary purpose of doing this is to avoid reconstructing the same sets over and over when, for example, we have a large number of lookups into the same module.  The context construct process supports both parallel and sequential construction, but does not attempt to subdivide the construction of a single set (which, in theory, it could).