### PR TITLE
feat: caller lookups for read-write memory accesses (3/3)

### DIFF
--- a/pkg/zkc/constraints/call_and_memory_lookup.go
+++ b/pkg/zkc/constraints/call_and_memory_lookup.go
@@ -85,8 +85,12 @@ func addLookups[W vm.Word[W], F field.Element[F]](mod *schema.Table[F, mir.Const
 					emitCallLookup(mod, ctx, callerRegs, uint(pc), uint(c.Target),
 						toRegisterIds(c.Arguments), toRegisterIds(c.Returns), srcSelector, infos)
 				case *vm.BytecodeReadWrite[W]:
-					emitMemoryLookup(mod, ctx, callerRegs, uint(pc), entry.cc, uint(c.Id),
-						toRegisterIds(c.Address), toRegisterIds(c.Data), srcSelector, infos)
+					if infos[c.Id].(*vm.Memory[W]).IsReadWrite() {
+						emitRamLookup(mod, ctx, uint(pc), entry.cc, c, srcSelector, infos, field)
+					} else {
+						emitMemoryLookup(mod, ctx, callerRegs, uint(pc), entry.cc, uint(c.Id),
+							toRegisterIds(c.Address), toRegisterIds(c.Data), srcSelector, infos)
+					}
 				}
 			}
 		}
@@ -111,7 +115,7 @@ type lookupEntry[W vm.Word[W]] struct {
 }
 
 // groupLookupsByCondition partitions the lookup-emitting bytecodes of a vector
-// (calls, and memory accesses other than RAM) by the branch condition under
+// (calls and memory accesses) by the branch condition under
 // which they execute.  Conditions are shortened against the given one-hot
 // groups first (see rewriteOneHotConditions), so that accesses within a
 // switch's default body are gated on the default bit rather than on the
@@ -122,17 +126,11 @@ func groupLookupsByCondition[W vm.Word[W]](codes []vm.Bytecode[W], branchTable d
 	//
 outer:
 	for cc, code := range codes {
-		switch c := code.(type) {
+		switch code.(type) {
 		case *vm.BytecodeCall[W]:
 			// always emits a lookup
 		case *vm.BytecodeReadWrite[W]:
-			// TODO: see https://github.com/LFDT-Lineth/zkc/issues/1807
-			// read-write (RAM) memories have no table constraints yet
-			// (see translateReadWriteMemory), so there is no sound lookup
-			// target for them.
-			if infos[c.Id].(*vm.Memory[W]).IsReadWrite() {
-				continue
-			}
+			// read-write and access-once memories alike emit a lookup.
 		default:
 			continue
 		}
@@ -356,6 +354,63 @@ func emitMemoryLookup[W vm.Word[W], F field.Element[F]](mod *schema.Table[F, mir
 		//
 		target = lookup.FilteredVector(memId, accessId, tgtIds...)
 	}
+	//
+	mod.AddConstraints(mir.NewLookupConstraint[F](handle, []mir.LookupVector{target}, []mir.LookupVector{source}))
+}
+
+// emitRamLookup constructs and adds the lookup constraint tying one read-write
+// (RAM) memory access to a row of that memory's table: the accessor's address,
+// data and (threaded) timestamp registers map onto the table's ADDRESS,
+// VALUE_WRITTEN and TIMESTAMP_WRITTEN columns.  The access's read/write kind is
+// pinned by the target-side filter: a write targets the table filtered by
+// EXEC_WRITE (= EXEC * IS_WRITE), a read by EXEC_READ (= EXEC * (1-IS_WRITE)).
+// A read's data registers are its outputs — the value read back — which the
+// table exposes in VALUE_WRITTEN too, since a read row "writes back" what it
+// found (VALUE_READ == VALUE_WRITTEN there).
+//
+// Together with the table's local constraints this pins every access's row;
+// that VALUE_READ genuinely returns the last value written to the address
+// remains for the offline memory-checking bus (see translateReadWriteMemory).
+func emitRamLookup[W vm.Word[W], F field.Element[F]](mod *schema.Table[F, mir.Constraint[F]],
+	ctx schema.ModuleId, pc, cc uint, rw *vm.BytecodeReadWrite[W],
+	srcSelector register.Id, infos []vm.Module[W], fieldCfg field.Config) {
+	//
+	var (
+		mem    = infos[rw.Id].(*vm.Memory[W])
+		layout = computeRamLayout(mem, fieldCfg)
+		// The bytecode index (cc) disambiguates two accesses to the same memory
+		// on the same code line.
+		handle = fmt.Sprintf("ram_%d_%d_%d_%d", ctx, pc, cc, rw.Id)
+		// Source ids: the accessor's address, data and timestamp registers.
+		// The timestamp is threaded on the constraint path only, so it is
+		// always present here; its limbs split exactly like the table's
+		// timestamp columns (same width, same field).
+		srcIds = append(append(append([]register.Id{},
+			toRegisterIds(rw.Address)...),
+			toRegisterIds(rw.Data)...),
+			toRegisterIds(rw.Stamp)...)
+		// Target ids: the table's ADDRESS, VALUE_WRITTEN and TIMESTAMP_WRITTEN
+		// columns, in the layout's fixed order.
+		tgtIds = append(append(append([]register.Id{},
+			layout.address...),
+			layout.valueWritten...),
+			layout.tsWritten...)
+		// Target-side filter pinning the access kind.
+		kind = layout.execRead
+	)
+	//
+	if len(rw.Stamp) == 0 {
+		panic(fmt.Sprintf("read-write memory access without a threaded timestamp (%s)", handle))
+	}
+	//
+	if rw.Write {
+		kind = layout.execWrite
+	}
+	//
+	var (
+		source = lookup.FilteredVector(ctx, srcSelector, srcIds...)
+		target = lookup.FilteredVector(uint(rw.Id), kind, tgtIds...)
+	)
 	//
 	mod.AddConstraints(mir.NewLookupConstraint[F](handle, []mir.LookupVector{target}, []mir.LookupVector{source}))
 }

--- a/pkg/zkc/constraints/ram.go
+++ b/pkg/zkc/constraints/ram.go
@@ -55,7 +55,7 @@ const stampWidth uint = 32
 //   - outputs  : []VALUE_WRITTEN           (declared data lines)
 //   - computed : EXEC, FINL, IS_WRITE, []VALUE_READ, []TIMESTAMP_WRITTEN,
 //     []TIMESTAMP_READ, []TIMESTAMP_DELTA, []ADDRESS_DELTA,
-//     []TS_CARRY, []ADDR_CARRY
+//     []TS_CARRY, []ADDR_CARRY, EXEC_WRITE, EXEC_READ
 //
 // All limb slices are most-significant-limb first (matching declaration /
 // "big endian" order used by ApplyLimbsMap and the module register order).
@@ -116,6 +116,13 @@ type ramLayout struct {
 	// by significance (index 0 == carry out of the least significant limb).
 	tsCarry   []register.Id
 	addrCarry []register.Id
+	// execWrite / execRead select the write (EXEC * IS_WRITE) and read
+	// (EXEC * (1 - IS_WRITE)) rows of the execution phase.  They exist because
+	// a lookup's target filter must be a single column: a caller's write-site
+	// lookup targets the table filtered by execWrite, a read-site lookup by
+	// execRead, which is how each access's read/write kind is pinned.
+	execWrite register.Id
+	execRead  register.Id
 	// Limb widths (most-significant first) of the address, data and timestamp
 	// register families.
 	addrWidths []uint
@@ -166,6 +173,9 @@ func computeRamLayout[W vm.Word[W]](m *vm.Memory[W], field field.Config) ramLayo
 	layout.tsCarry = idRange(next, nStamp-1)
 	next += nStamp - 1
 	layout.addrCarry = idRange(next, nAddr-1)
+	next += nAddr - 1
+	layout.execWrite = register.NewId(next)
+	layout.execRead = register.NewId(next + 1)
 	//
 	return layout
 }
@@ -236,6 +246,10 @@ func translateReadWriteMemory[W vm.Word[W], F field.Element[F]](
 	addLimbRegisters(mod, tracer.RAM_ADDR_DELTA_PREFIX, layout.addrWidths, padding)
 	addCarryRegisters(mod, tracer.RAM_TS_CARRY_PREFIX, len(layout.tsCarry), padding)
 	addCarryRegisters(mod, tracer.RAM_ADDR_CARRY_PREFIX, len(layout.addrCarry), padding)
+	mod.AddRegisters(
+		register.NewComputed(tracer.RAM_EXEC_WRITE_NAME, 1, padding),
+		register.NewComputed(tracer.RAM_EXEC_READ_NAME, 1, padding),
+	)
 	// Local (per-row) consistency constraints.
 	mod.AddConstraints(ramGeneralConstraints[F](ctx, layout)...)
 	mod.AddConstraints(ramExecConstraints[F](ctx, layout)...)
@@ -286,6 +300,8 @@ func ramGeneralConstraints[F field.Element[F]](ctx schema.ModuleId, l ramLayout)
 		prevFinl  = mirc.Variable[register.Id, Expr[F]](l.finl, 1, -1)
 		prevExec  = mirc.Variable[register.Id, Expr[F]](l.exec, 1, -1)
 		prevActiv = prevExec.Add(prevFinl)
+		execWrite = mirc.Variable[register.Id, Expr[F]](l.execWrite, 1, 0)
+		execRead  = mirc.Variable[register.Id, Expr[F]](l.execRead, 1, 0)
 	)
 	//
 	return []mir.Constraint[F]{
@@ -306,6 +322,13 @@ func ramGeneralConstraints[F field.Element[F]](ctx schema.ModuleId, l ramLayout)
 		// (EXEC+FINL) nondecreasing: active[i-1] == 1 => active[i] == 1.
 		mir.NewVanishingConstraint("active_monotony", ctx, util.None[int](),
 			mirc.If(prevActiv.Equals(one), active.Equals(one)).AsLogical()),
+		// The per-kind lookup selectors are fully determined:
+		// EXEC_WRITE == EXEC * IS_WRITE, and EXEC_READ == EXEC * (1 - IS_WRITE)
+		// expressed subtraction-free as EXEC_WRITE + EXEC_READ == EXEC.
+		mir.NewVanishingConstraint("exec_write_def", ctx, util.None[int](),
+			execWrite.Equals(exec.Multiply(isWrite)).AsLogical()),
+		mir.NewVanishingConstraint("exec_read_def", ctx, util.None[int](),
+			execWrite.Add(execRead).Equals(exec).AsLogical()),
 	}
 }
 

--- a/pkg/zkc/constraints/trace/builder.go
+++ b/pkg/zkc/constraints/trace/builder.go
@@ -75,6 +75,12 @@ const (
 	// RAM_ADDR_CARRY_PREFIX prefixes the per-boundary carry columns witnessing the
 	// multi-limb address addition in the finalization phase.
 	RAM_ADDR_CARRY_PREFIX = "$addr_carry_"
+	// RAM_EXEC_WRITE_NAME is the binary column EXEC * IS_WRITE: the target-side
+	// selector of the caller->RAM lookup for write accesses.
+	RAM_EXEC_WRITE_NAME = "$exec_write"
+	// RAM_EXEC_READ_NAME is the binary column EXEC * (1 - IS_WRITE): the
+	// target-side selector of the caller->RAM lookup for read accesses.
+	RAM_EXEC_READ_NAME = "$exec_read"
 )
 
 // RamLimbName returns the name of the limb-k column of a RAM register family

--- a/pkg/zkc/constraints/trace/process_ram.go
+++ b/pkg/zkc/constraints/trace/process_ram.go
@@ -34,12 +34,14 @@ const ramStampWidth uint = 32
 // match constraints.computeRamLayout (the schema this trace is checked against):
 // [ADDRESS, VALUE_WRITTEN, EXEC, FINL, IS_WRITE, VALUE_READ, TIMESTAMP_WRITTEN,
 //
-//	TIMESTAMP_READ, TIMESTAMP_DELTA, ADDRESS_DELTA, TS_CARRY, ADDR_CARRY].
+//	TIMESTAMP_READ, TIMESTAMP_DELTA, ADDRESS_DELTA, TS_CARRY, ADDR_CARRY,
+//	EXEC_WRITE, EXEC_READ].
 type ramTraceLayout struct {
 	nAddr, nData, nStamp                         int
 	valueWritten, exec, finl, isWrite, valueRead int
 	tsWritten, tsRead, tsDelta                   int
 	addrDelta, tsCarry, addrCarry                int
+	execWrite, execRead                          int
 	width                                        int
 }
 
@@ -60,7 +62,9 @@ func newRamTraceLayout(nAddr, nData, nStamp int) ramTraceLayout {
 	l.addrDelta = l.tsDelta + nStamp
 	l.tsCarry = l.addrDelta + nAddr
 	l.addrCarry = l.tsCarry + (nStamp - 1)
-	l.width = l.addrCarry + (nAddr - 1)
+	l.execWrite = l.addrCarry + (nAddr - 1)
+	l.execRead = l.execWrite + 1
+	l.width = l.execRead + 1
 	//
 	return l
 }
@@ -110,6 +114,11 @@ func initReadWriteMemory[W Word[W], F Element[F], M ModuleBuilder[F, M]](cfg fie
 	for k := uint(1); k < m.NumInputs(); k++ {
 		regs = append(regs, rtrace.NewColumnDescriptor(RamLimbName(RAM_ADDR_CARRY_PREFIX, k-1), u1))
 	}
+	// EXEC_WRITE / EXEC_READ (the per-kind lookup selectors).
+	regs = append(regs,
+		rtrace.NewColumnDescriptor(RAM_EXEC_WRITE_NAME, u1),
+		rtrace.NewColumnDescriptor(RAM_EXEC_READ_NAME, u1),
+	)
 	//Done
 	return module.Initialise(m.Name(), regs)
 }
@@ -156,9 +165,13 @@ func traceReadWriteMemory[W Word[W], F Element[F]](m vm.RuntimeMemory[W], module
 			tsWr    = acc.timestamp
 			tsDelta = tsWr - tsRead - 1
 		)
-		// EXEC = 1, IS_WRITE from the access; FINL = 0 (zero value).
+		// EXEC = 1, IS_WRITE from the access; FINL = 0 (zero value).  The
+		// per-kind lookup selectors follow: EXEC_WRITE = EXEC * IS_WRITE,
+		// EXEC_READ = EXEC * (1 - IS_WRITE).
 		row[layout.exec] = field.Uint64[F](1)
 		row[layout.isWrite] = field.Uint1[F](acc.isWrite)
+		row[layout.execWrite] = field.Uint1[F](acc.isWrite)
+		row[layout.execRead] = field.Uint1[F](!acc.isWrite)
 		// ADDRESS (logical) split across the address lanes (offset 0).
 		copyAddressLines(logical, addrRegs, row[0:nAddr])
 		// VALUE_WRITTEN / VALUE_READ per lane.


### PR DESCRIPTION
Re-lands #2081, which was accidentally merged into `1807-ram-constraints` instead of `main`. That branch was subsequently rewritten from the ground up and merged separately, so the lookup work never reached `main`. This is a port onto current `main`, not a cherry-pick — the surrounding code moved (see below).

## What this does

Every read-write memory access now emits a lookup tying it to a row of that memory's table, through the same per-site machinery already used for calls and access-once memories. The source tuple carries the accessor's address, data and threaded timestamp registers (gated by the shared line/path selector) and maps onto the table's `ADDRESS`, `VALUE_WRITTEN` and `TIMESTAMP_WRITTEN` columns. A read's data registers are its outputs — the value read back — which the table exposes in `VALUE_WRITTEN` too, since a read row writes back what it found.

The access's read/write kind is pinned by the **target-side filter** rather than a tuple element, because MIR lookup tuples carry register accesses only. The table gains two fully-determined selector columns, `EXEC_WRITE = EXEC * IS_WRITE` and `EXEC_READ` (constrained subtraction-free as `EXEC_WRITE + EXEC_READ == EXEC`), filled by the trace observer. A write site's lookup targets the table filtered by `EXEC_WRITE`, a read site's by `EXEC_READ`.

With this, the guest-facing columns of every access row are pinned by the caller and the row-local constraints hold end-to-end. The remaining gap — that `VALUE_READ` genuinely returns the last value written to the address — is the offline memory-checking bus (#2068).

Part 3 of 3 of the RAM timestamps feature (#1807).

## Differences from #2081

The port is smaller than the original (112 vs 130 insertions) because `main` has since changed underneath it:

- `lookup.FilteredVector` / `NewLookupConstraint` now take `register.Id`s directly instead of term-level register accesses, and `mir.LookupVector` is no longer generic. `emitRamLookup` therefore drops the width plumbing and the `accessorRegs` parameter that the original needed.
- The RAM column-name constants moved from `pkg/asm/io/function.go` (that package is gone) into `pkg/zkc/constraints/trace/builder.go`.
- `pkg/zkc/constraints/post/` → `pkg/zkc/constraints/trace/`, and `determineRamRegisters` → `initReadWriteMemory` using `rtrace.NewColumnDescriptor`. The observer sets the new selectors via the existing `field.Uint1[F]` helper rather than the original's `if`/`else`.

The fixup commit that rode along in #2081 (`fix: restore dispatch-case retargeting dropped by the ours-strategy merge`) is **not** included: its content — the retargeting logic, the `ram_11` fixture and its test — is already on `main` via the rewritten constraints branch.

## Review guide

- `constraints/ram.go` — the two selector columns, their layout slots, and the `exec_write_def` / `exec_read_def` constraints that fully determine them.
- `constraints/call_and_memory_lookup.go` — `emitRamLookup`, plus removal of the `groupLookupsByCondition` skip that used to exclude RAM (the TODO pointing at #1807 is now resolved).
- `constraints/trace/process_ram.go` — the observer filling `EXEC_WRITE` / `EXEC_READ`, and the widened row layout.
- Worth checking: the column order in `computeRamLayout`, `newRamTraceLayout` and `initReadWriteMemory` must stay in lock-step; the new columns are appended last in all three.

## Testing

- `make lint` — 0 issues.
- `make zkc-unit-test` — full suite green (~500s), covering the 11 `ram_*` fixtures across fields, heights and padding strategies.
- `make unit-test` — green.
- Verified the constraints are actually emitted (not a silent no-op) via `zkc compile --mir testdata/zkc/unit/ram_02.zkc`: read sites filter on `ram:$exec_read`, write sites on `ram:$exec_write`, both targeting `(address, byte, $ts_written_*)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)