### PR TITLE
feat: support CLI options for compile command

### DIFF
--- a/pkg/cmd/zkc/compile.go
+++ b/pkg/cmd/zkc/compile.go
@@ -80,6 +80,8 @@ type CompileConfig struct {
 	// order determines how modules are ordered in the --stats output
 	// (name|total|complexity|lookups).
 	order string
+	// indicates whether or not to print skip arrows
+	skipArrows bool
 	// indicates whether or not to print everything in full (e.g. including
 	// static reference tables).
 	verbose bool
@@ -100,6 +102,7 @@ func runCompileCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 	config.air = GetFlag(cmd, "air")
 	config.stats = GetFlag(cmd, "stats")
 	config.order = GetString(cmd, "order")
+	config.skipArrows = GetFlag(cmd, "show-skips")
 	config.statsMatrix = GetVerboseLevel(cmd) >= VERBOSE_INFO
 	// Compile verbosity is the highest verbosity level.
 	config.verbose = GetVerboseLevel(cmd) >= VERBOSE_PRINTF
@@ -181,13 +184,13 @@ func printArtifacts[F field.Element[F]](ast *ast.Program, bf *constraints.Binary
 	// Word-level Intermediate Representation
 	if ir && config.raw {
 		// Raw IR
-		writeBytecodeProgram(config.verbose, ast, bf.RawProgram())
+		writeBytecodeProgram(config.verbose, ast, bf.RawProgram(), config)
 	} else if ir && config.build.fastMode {
 		// Execution IR
-		writeBytecodeProgram(config.verbose, ast, bf.ExecutionProgram())
+		writeBytecodeProgram(config.verbose, ast, bf.ExecutionProgram(), config)
 	} else if ir {
 		// Tracing IR
-		writeBytecodeProgram(config.verbose, ast, bf.TracingProgram())
+		writeBytecodeProgram(config.verbose, ast, bf.TracingProgram(), config)
 	}
 	// Mid-level Intermediate Representation
 	if config.mir {
@@ -542,7 +545,7 @@ func (p *bytecodeListing) table() *termio.FormattedTable {
 	return tbl
 }
 
-func writeBytecodeProgram[W vm.Word[W]](binary bool, ast *ast.Program, program vm.Program[W]) {
+func writeBytecodeProgram[W vm.Word[W]](binary bool, ast *ast.Program, program vm.Program[W], config CompileConfig) {
 	var (
 		bin           [][]uint32
 		address       uint32
@@ -566,7 +569,8 @@ func writeBytecodeProgram[W vm.Word[W]](binary bool, ast *ast.Program, program v
 			fmt.Println()
 		}
 		// Write and print this module's table
-		address, bin = writeBytecodeModule(binary, encodingWidth, uint16(i), program, m, annotations, address, bin)
+		address, bin = writeBytecodeModule(binary, encodingWidth, uint16(i), program, m, annotations,
+			address, bin, config.skipArrows)
 	}
 }
 
@@ -591,7 +595,7 @@ func annotationsOf(program *ast.Program) map[string][]string {
 // The encoding stream (bin) and running instruction address are threaded
 // through (and returned) since they accumulate across the whole program.
 func writeBytecodeModule[W vm.Word[W]](binary bool, encodingWidth uint, fid uint16, program vm.Program[W],
-	m vm.Module[W], annotations map[string][]string, address uint32, bin [][]uint32) (uint32, [][]uint32) {
+	m vm.Module[W], annotations map[string][]string, address uint32, bin [][]uint32, arrows bool) (uint32, [][]uint32) {
 	//
 	listing := &bytecodeListing{binary: binary, encodingWidth: encodingWidth}
 	// Write any annotations for this module
@@ -601,7 +605,7 @@ func writeBytecodeModule[W vm.Word[W]](binary bool, encodingWidth uint, fid uint
 	// Write module contents
 	switch m := m.(type) {
 	case *vm.Function[W]:
-		address, bin = writeBytecodeFunction(listing, address, program.EnvironmentOf(fid), m, bin)
+		address, bin = writeBytecodeFunction(listing, address, program.EnvironmentOf(fid), m, bin, arrows)
 	case *vm.Memory[W]:
 		writeBytecodeMemory(listing, m)
 	default:
@@ -610,7 +614,7 @@ func writeBytecodeModule[W vm.Word[W]](binary bool, encodingWidth uint, fid uint
 	//
 	writeModuleSignature(m)
 	// Print this module's table
-	listing.table().Print(true)
+	listing.table().Print(AnsiEscapes)
 	//
 	return address, bin
 }
@@ -644,10 +648,10 @@ func writeModuleSignature[W vm.Word[W]](m vm.Module[W]) {
 }
 
 func writeBytecodeFunction[W vm.Word[W]](listing *bytecodeListing, address uint32, env vm.BytecodeEnvironment[W],
-	f *vm.Function[W], bin [][]uint32) (uint32, [][]uint32) {
+	f *vm.Function[W], bin [][]uint32, skips bool) (uint32, [][]uint32) {
 	for _, r := range f.Registers() {
 		if !r.IsInputOutput() {
-			listing.addDeclaration(fmt.Sprintf("  %s %s", regType(r), r.Name()))
+			listing.addDeclaration(fmt.Sprintf("  var %s:%s", r.Name(), regType(r)))
 		}
 	}
 	// First pass: gather each bytecode's display fields, and record the
@@ -692,11 +696,19 @@ func writeBytecodeFunction[W vm.Word[W]](listing *bytecodeListing, address uint3
 			idx++
 		}
 	}
-	// Render the flow graph across all bytecode rows of this function.
-	arrows := flow.Render(idx)
-	// Second pass: emit each instruction row alongside its flow-graph column.
-	for i, row := range insns {
-		listing.addInstruction(row.address, row.encoding, row.marker, row.text, arrows[i])
+	//
+	if skips {
+		// Render the flow graph across all bytecode rows of this function.
+		arrows := flow.Render(idx)
+		// Second pass: emit each instruction row alongside its flow-graph column.
+		for i, row := range insns {
+			listing.addInstruction(row.address, row.encoding, row.marker, row.text, arrows[i])
+		}
+	} else {
+		// Don't print skip arrows
+		for _, row := range insns {
+			listing.addInstruction(row.address, row.encoding, row.marker, row.text, "")
+		}
 	}
 	//
 	return address, bin
@@ -798,6 +810,7 @@ func init() {
 	compileCmd.PersistentFlags().Bool("mir", false, "Output Mid-Level Intermediate Representation (MIR)")
 	compileCmd.PersistentFlags().Bool("air", false, "Output Arithmetic Intermediate Representation (AIR)")
 	compileCmd.PersistentFlags().Bool("stats", false, "Output summary statistics")
+	compileCmd.PersistentFlags().Bool("show-skips", true, "Show skip arrows explicitly")
 	compileCmd.PersistentFlags().String("order", "total",
 		"module ordering for --stats (name|total|complexity|lookups)")
 	// --order only affects the --stats output.

--- a/pkg/cmd/zkc/execute.go
+++ b/pkg/cmd/zkc/execute.go
@@ -155,7 +155,7 @@ func checkConstraints[F field.Element[F]](binfile *constraints.BinaryFile[F], tr
 	checkConfig.ReportPadding = 2
 	checkConfig.ReportLimbs = true
 	checkConfig.ReportComputed = true
-	checkConfig.AnsiEscapes = true
+	checkConfig.AnsiEscapes = AnsiEscapes
 	// Construct limbs map
 	mapping := binfile.LimbsMap()
 	// Run the check

--- a/pkg/cmd/zkc/root.go
+++ b/pkg/cmd/zkc/root.go
@@ -30,11 +30,21 @@ import (
 // install".
 var Version string
 
+// AnsiEscapes determine whether or not to output with ANSI escapes enabled.
+var AnsiEscapes bool
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "zkc",
 	Short: "A compiler for the ZkC language.",
 	Long:  "A compiler (and general toolbox) for the ZkC language.",
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Read the --ansi-escapes flag once here so that every subcommand
+		// (including those that do not route through runFieldAgnosticCmd,
+		// such as `format` and `lsp`) honours it.
+		AnsiEscapes = GetFlag(cmd, "ansi-escapes")
+		return nil
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if GetFlag(cmd, "version") {
 			fmt.Print("zkc ")
@@ -184,4 +194,6 @@ func init() {
 	// profiling commands'
 	rootCmd.PersistentFlags().String("cpuprof", "", "write cpu profile to `file`")
 	rootCmd.PersistentFlags().String("memprof", "", "write memory profile to `file`")
+	rootCmd.PersistentFlags().Bool("ansi-escapes", true,
+		"specify whether to allow ANSI escapes or not (e.g. for colour reports)")
 }

--- a/pkg/cmd/zkc/stats.go
+++ b/pkg/cmd/zkc/stats.go
@@ -735,7 +735,7 @@ func renderStatsTable(cols []*statsColumn, stats []moduleStats) {
 	tbl.SetRule(2 + uint(len(totals)))
 	tbl.SetRule(nrows)
 	//
-	tbl.Print(true)
+	tbl.Print(AnsiEscapes)
 }
 
 // typeTotals computes one totals row per module type present, in type order,

--- a/pkg/cmd/zkc/trace.go
+++ b/pkg/cmd/zkc/trace.go
@@ -253,7 +253,7 @@ func printTraceStats[F field.Element[F]](rtr trace.Trace[F]) {
 	}
 	//
 	tbl.SetMaxWidths(64)
-	tbl.Print(true)
+	tbl.Print(AnsiEscapes)
 }
 
 // humanCount formats a (potentially large) count using K/M/G suffixes, matching
@@ -335,7 +335,7 @@ func printModuleStats[F field.Element[F]](rtr trace.Trace[F]) {
 	fmt.Println(strings.Repeat("-", int(tbl.PrintedWidth())))
 	// Sort modules (descending) by cell count, skipping the title row.
 	tbl.Sort(1, termio.NewTableSorter().SortNumericalColumn(4).Invert())
-	tbl.Print(true)
+	tbl.Print(AnsiEscapes)
 }
 
 // byteWidth returns the number of bytes required to hold a value of the given


### PR DESCRIPTION
This puts through two specific CLI options: (1) to disable ANSI escapes upon request; (2) to prevent "skip arrows" from being shown upon request.  These are really just to assist with controlling the output for debugging / analysis reasons.

More details (from Claude): Small quality-of-life PR: two new flags to tame the
  tool's output for debugging and analysis (e.g. piping to a file or diffing).

  1. --ansi-escapes (global, default true). Set it to false to strip
     colour/escape codes¹ from all output.
     - 1.a A package-level AnsiEscapes variable in root.go, filled in
       once in a PersistentPreRunE hook so every subcommand sees it.
     - 1.b All the hard-coded tbl.Print(true) call sites (compile, stats,
       trace) and the constraint-check report in execute.go now pass that
       variable instead of true.
  2. --show-skips (compile command, default true). Set to false to drop the
     "skip arrows" — the drawn flow-graph column showing where conditional
     skips jump to — from the bytecode listing. When off, each row just gets
     an empty string where the arrows would be.

  Both default to on, so plain invocations behave exactly as before; you
  opt out with --ansi-escapes=false / --show-skips=false.